### PR TITLE
feat: Pass frame's IOSurface handle to Electron renderer

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -42,6 +42,8 @@
                 './src/addon/event-listeners/DirectoryEventListener.mm',
                 './src/addon/event-listeners/FrameEventListener.h',
                 './src/addon/event-listeners/FrameEventListener.mm',
+                './src/addon/event-listeners/TextureEventListener.h',
+                './src/addon/event-listeners/TextureEventListener.mm',
                 './src/addon/event-listeners/StringEventListener.h',
                 './src/addon/event-listeners/StringEventListener.mm',
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -73,9 +73,7 @@
                         'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
                         'GCC_ENABLE_CPP_RTTI': 'YES',
                         'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES',
-                        'OTHER_CFLAGS': [
-                            '-ObjC++'
-                        ],
+                        'OTHER_CFLAGS': [],
                         "LD_RUNPATH_SEARCH_PATHS": [
                             # TODO: Is this useful?
                             "@loader_path/../Frameworks",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-syphon",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "license": "GPL-3.0+",
   "description": "Superficial bindings between Syphon-Framework and node.js.",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-syphon",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "license": "GPL-3.0+",
   "description": "Superficial bindings between Syphon-Framework and node.js.",
   "author": {

--- a/src/addon/directory/ServerDirectory.h
+++ b/src/addon/directory/ServerDirectory.h
@@ -1,29 +1,27 @@
 #ifndef ___SERVER_DIRECTORY_H___
 #define ___SERVER_DIRECTORY_H___
 
-#include <napi.h>
-#include <Foundation/Foundation.h>
 #include <Cocoa/Cocoa.h>
+#include <Foundation/Foundation.h>
 #include <Syphon/Syphon.h>
+#include <napi.h>
 
-namespace syphon
-{
+namespace syphon {
 
-  class ServerDirectoryWrapper : public Napi::ObjectWrap<ServerDirectoryWrapper>
-  {
-  public:
-    static Napi::Object Init(Napi::Env env, Napi::Object exports);
+class ServerDirectoryWrapper : public Napi::ObjectWrap<ServerDirectoryWrapper> {
+public:
+  static Napi::Object Init(Napi::Env env, Napi::Object exports);
 
-    ServerDirectoryWrapper(const Napi::CallbackInfo &info);
-    ~ServerDirectoryWrapper();
+  ServerDirectoryWrapper(const Napi::CallbackInfo &info);
+  ~ServerDirectoryWrapper();
 
-    void Dispose(const Napi::CallbackInfo &info);
-    void Listen(const Napi::CallbackInfo &info);
+  void Dispose(const Napi::CallbackInfo &info);
+  void Listen(const Napi::CallbackInfo &info);
 
-  private:
-    static Napi::FunctionReference constructor;
-    void _Dispose();
-  };
-}
+private:
+  static Napi::FunctionReference constructor;
+  void _Dispose();
+};
+} // namespace syphon
 
 #endif

--- a/src/addon/directory/ServerDirectory.mm
+++ b/src/addon/directory/ServerDirectory.mm
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include <iostream>
+#include <stdio.h>
 
 #include "ServerDirectory.h"
 
@@ -19,82 +19,81 @@ id _update_observer;
 
 void sigHandler(int sig) {
 
-    // This is the same as our instance's _Dispose method.
-    
-    printf("{\"NodeSyphonMessageType\": \"NodeSyphonMessageInfo\", \"NodeSyphonMessage\": \"Signal handler called: stopping NSRunLoop...\"}\n");
-    
-    CFRunLoopStop([[NSRunLoop currentRunLoop] getCFRunLoop]);
+  // This is the same as our instance's _Dispose method.
 
-    [[NSNotificationCenter defaultCenter] removeObserver:_announce_observer];
-    [[NSNotificationCenter defaultCenter] removeObserver:_retire_observer];
-    [[NSNotificationCenter defaultCenter] removeObserver:_update_observer];
+  printf("{\"NodeSyphonMessageType\": \"NodeSyphonMessageInfo\", "
+         "\"NodeSyphonMessage\": \"Signal handler called: stopping "
+         "NSRunLoop...\"}\n");
 
-    _announce_observer = nil;
-    _retire_observer = nil;
-    _update_observer = nil;
-    
-    exit(0);
+  CFRunLoopStop([[NSRunLoop currentRunLoop] getCFRunLoop]);
+
+  [[NSNotificationCenter defaultCenter] removeObserver:_announce_observer];
+  [[NSNotificationCenter defaultCenter] removeObserver:_retire_observer];
+  [[NSNotificationCenter defaultCenter] removeObserver:_update_observer];
+
+  _announce_observer = nil;
+  _retire_observer = nil;
+  _update_observer = nil;
+
+  exit(0);
 }
 
-NSString * toJSON(NSString *type, NSDictionary *dic) {
-    NSString *json = [NSString stringWithFormat:
-                        @"{"
-                        @"\"%@\": \"%@\","
-                        @"\"%@\": {"
+NSString *toJSON(NSString *type, NSDictionary *dic) {
+  NSString *json = [NSString
+      stringWithFormat:
+          @"{"
+          @"\"%@\": \"%@\","
+          @"\"%@\": {"
 
-                        // App name
-                        @"\"%@\": "
-                        @"\"%@\","
+          // App name
+          @"\"%@\": "
+          @"\"%@\","
 
-                        // Name
-                        @"\"%@\": "
-                        @"\"%@\","
+          // Name
+          @"\"%@\": "
+          @"\"%@\","
 
-                        // UUID
-                        @"\"%@\": "
-                        @"\"%@\","
+          // UUID
+          @"\"%@\": "
+          @"\"%@\","
 
-                        // Version
-                        @"\"%@\": "
-                        @"%i,"
+          // Version
+          @"\"%@\": "
+          @"%i,"
 
-                        // Surface
-                        @"\"%@\": "
-                        @"["
-                        @"{"
-                        @"\"%@\": "
-                        @"\"%@\""
-                        @"}"
-                        @"]"
+          // Surface
+          @"\"%@\": "
+          @"["
+          @"{"
+          @"\"%@\": "
+          @"\"%@\""
+          @"}"
+          @"]"
 
-                        // End
-                        @"}"
-                        @"}",
-                        NodeSyphonNotificationTypeKey,
-                        type,
-                        NodeSyphonServerDictionaryKey,
-                        SyphonServerDescriptionAppNameKey,
-                        [dic objectForKey:SyphonServerDescriptionAppNameKey],
-                        SyphonServerDescriptionNameKey,
-                        [dic objectForKey:SyphonServerDescriptionNameKey],
-                        SyphonServerDescriptionUUIDKey,
-                        [dic objectForKey: SyphonServerDescriptionUUIDKey],
-                        @"SyphonServerDescriptionDictionaryVersionKey",
-                        [[dic objectForKey: @"SyphonServerDescriptionDictionaryVersionKey"] intValue],
-                        @"SyphonServerDescriptionSurfacesKey",
-                        @"SyphonSurfaceType",
-                        @"SyphonSurfaceTypeIOSurface"
-                      ];
-    
-    return json;
+          // End
+          @"}"
+          @"}",
+          NodeSyphonNotificationTypeKey, type, NodeSyphonServerDictionaryKey,
+          SyphonServerDescriptionAppNameKey,
+          [dic objectForKey:SyphonServerDescriptionAppNameKey],
+          SyphonServerDescriptionNameKey,
+          [dic objectForKey:SyphonServerDescriptionNameKey],
+          SyphonServerDescriptionUUIDKey,
+          [dic objectForKey:SyphonServerDescriptionUUIDKey],
+          @"SyphonServerDescriptionDictionaryVersionKey",
+          [[dic objectForKey:@"SyphonServerDescriptionDictionaryVersionKey"]
+              intValue],
+          @"SyphonServerDescriptionSurfacesKey", @"SyphonSurfaceType",
+          @"SyphonSurfaceTypeIOSurface"];
+
+  return json;
 }
 
 using namespace syphon;
 
 Napi::FunctionReference ServerDirectoryWrapper::constructor;
-ServerDirectoryWrapper::ServerDirectoryWrapper(const Napi::CallbackInfo& info)
-: Napi::ObjectWrap<ServerDirectoryWrapper>(info)
-{
+ServerDirectoryWrapper::ServerDirectoryWrapper(const Napi::CallbackInfo &info)
+    : Napi::ObjectWrap<ServerDirectoryWrapper>(info) {
   Napi::Env env = info.Env();
   Napi::HandleScope scope(env);
 
@@ -105,57 +104,70 @@ ServerDirectoryWrapper::ServerDirectoryWrapper(const Napi::CallbackInfo& info)
   signal(SIGTERM, sigHandler);
 }
 
-ServerDirectoryWrapper::~ServerDirectoryWrapper()
-{
+ServerDirectoryWrapper::~ServerDirectoryWrapper() { _Dispose(); }
+
+void ServerDirectoryWrapper::Dispose(const Napi::CallbackInfo &info) {
   _Dispose();
 }
 
-void ServerDirectoryWrapper::Dispose(const Napi::CallbackInfo& info)
-{
-  _Dispose();
-}
-
-void ServerDirectoryWrapper::Listen(const Napi::CallbackInfo& info)
-{
+void ServerDirectoryWrapper::Listen(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
   Napi::HandleScope scope(env);
 
   // \n at the end of line to flush.
-  // See https://stackoverflow.com/questions/39180642/why-does-printf-not-produce-any-output
+  // See
+  // https://stackoverflow.com/questions/39180642/why-does-printf-not-produce-any-output
 
-  // Very hacky way to communicate with main process from spawn server directory.
-  printf("{\"NodeSyphonMessageType\": \"NodeSyphonMessageInfo\", \"NodeSyphonMessage\": \"Listening to Syphon directory server notifications...\"}\n");
+  // Very hacky way to communicate with main process from spawn server
+  // directory.
+  printf("{\"NodeSyphonMessageType\": \"NodeSyphonMessageInfo\", "
+         "\"NodeSyphonMessage\": \"Listening to Syphon directory server "
+         "notifications...\"}\n");
 
-  _announce_observer = [[NSNotificationCenter defaultCenter] addObserverForName:SyphonServerAnnounceNotification
-    object: nil
-    queue: nil
-    usingBlock: ^ (NSNotification * notification) {
-      printf("{\"NodeSyphonMessageType\": \"NodeSyphonMessageNotification\", \"NodeSyphonMessage\": \%s}\n", [toJSON(SyphonServerAnnounceNotification, [notification userInfo]) UTF8String]);
-    }
-  ];
+  _announce_observer = [[NSNotificationCenter defaultCenter]
+      addObserverForName:SyphonServerAnnounceNotification
+                  object:nil
+                   queue:nil
+              usingBlock:^(NSNotification *notification) {
+                printf("{\"NodeSyphonMessageType\": "
+                       "\"NodeSyphonMessageNotification\", "
+                       "\"NodeSyphonMessage\": \%s}\n",
+                       [toJSON(SyphonServerAnnounceNotification,
+                               [notification userInfo]) UTF8String]);
+              }];
 
-  _retire_observer = [[NSNotificationCenter defaultCenter] addObserverForName:SyphonServerRetireNotification
-    object: nil
-    queue: nil
-    usingBlock: ^ (NSNotification * notification) {
-      printf("{\"NodeSyphonMessageType\": \"NodeSyphonMessageNotification\", \"NodeSyphonMessage\": \%s}\n", [toJSON(SyphonServerRetireNotification, [notification userInfo]) UTF8String]);
-    }
-  ];
+  _retire_observer = [[NSNotificationCenter defaultCenter]
+      addObserverForName:SyphonServerRetireNotification
+                  object:nil
+                   queue:nil
+              usingBlock:^(NSNotification *notification) {
+                printf("{\"NodeSyphonMessageType\": "
+                       "\"NodeSyphonMessageNotification\", "
+                       "\"NodeSyphonMessage\": \%s}\n",
+                       [toJSON(SyphonServerRetireNotification,
+                               [notification userInfo]) UTF8String]);
+              }];
 
-  _update_observer = [[NSNotificationCenter defaultCenter] addObserverForName:SyphonServerUpdateNotification
-    object: nil
-    queue: nil
-    usingBlock: ^ (NSNotification * notification) {
-      printf("{\"NodeSyphonMessageType\": \"NodeSyphonMessageNotification\", \"NodeSyphonMessage\": \%s}\n", [toJSON(SyphonServerUpdateNotification, [notification userInfo]) UTF8String]);
-    }
-  ];
+  _update_observer = [[NSNotificationCenter defaultCenter]
+      addObserverForName:SyphonServerUpdateNotification
+                  object:nil
+                   queue:nil
+              usingBlock:^(NSNotification *notification) {
+                printf("{\"NodeSyphonMessageType\": "
+                       "\"NodeSyphonMessageNotification\", "
+                       "\"NodeSyphonMessage\": \%s}\n",
+                       [toJSON(SyphonServerUpdateNotification,
+                               [notification userInfo]) UTF8String]);
+              }];
 
   [[NSRunLoop currentRunLoop] run];
 }
 
 void ServerDirectoryWrapper::_Dispose() {
 
-  printf("{\"NodeSyphonMessageType\": \"NodeSyphonMessageInfo\", \"NodeSyphonMessage\": \"Dispose server directory...\"}\n");
+  printf("{\"NodeSyphonMessageType\": \"NodeSyphonMessageInfo\", "
+         "\"NodeSyphonMessage\": \"Dispose server directory...\"}\n");
+
   if (_announce_observer) {
     CFRunLoopStop([[NSRunLoop currentRunLoop] getCFRunLoop]);
 
@@ -167,23 +179,23 @@ void ServerDirectoryWrapper::_Dispose() {
     _retire_observer = nil;
     _update_observer = nil;
   }
-
 }
 
 // Class definition.
 
-Napi::Object ServerDirectoryWrapper::Init(Napi::Env env, Napi::Object exports)
-{
+Napi::Object ServerDirectoryWrapper::Init(Napi::Env env, Napi::Object exports) {
   Napi::HandleScope scope(env);
 
-  Napi::Function func = DefineClass(env, "ServerDirectory", {
+  Napi::Function func = DefineClass(
+      env, "ServerDirectory",
+      {
 
-    // Methods.
+          // Methods.
 
-    InstanceMethod("listen", &ServerDirectoryWrapper::Listen),
-    InstanceMethod("dispose", &ServerDirectoryWrapper::Dispose),
+          InstanceMethod("listen", &ServerDirectoryWrapper::Listen),
+          InstanceMethod("dispose", &ServerDirectoryWrapper::Dispose),
 
-  });
+      });
 
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
@@ -191,5 +203,4 @@ Napi::Object ServerDirectoryWrapper::Init(Napi::Env env, Napi::Object exports)
   exports.Set("ServerDirectory", func);
 
   return exports;
-
 }

--- a/src/addon/event-listeners/DirectoryEventListener.h
+++ b/src/addon/event-listeners/DirectoryEventListener.h
@@ -1,28 +1,26 @@
 #ifndef __DIRECTORY_EVENT_LISTENER__
 #define __DIRECTORY_EVENT_LISTENER__
 
-#include <napi.h>
-#include <Foundation/Foundation.h>
 #include <Cocoa/Cocoa.h>
+#include <Foundation/Foundation.h>
 #include <Syphon/Syphon.h>
+#include <napi.h>
 
-namespace syphon
-{
+namespace syphon {
 
-  class DirectoryEventListener
-  {
-    public:
-        DirectoryEventListener();
-        ~DirectoryEventListener();
+class DirectoryEventListener {
+public:
+  DirectoryEventListener();
+  ~DirectoryEventListener();
 
-        void Dispose();
+  void Dispose();
 
-        void Set(Napi::Env env, Napi::Function listener);
-        void Call(NSDictionary * dictionary);
+  void Set(Napi::Env env, Napi::Function listener);
+  void Call(NSDictionary *dictionary);
 
-    private:
-      Napi::ThreadSafeFunction m_listener;
-  };
-}
+private:
+  Napi::ThreadSafeFunction m_listener;
+};
+} // namespace syphon
 
 #endif

--- a/src/addon/event-listeners/DirectoryEventListener.mm
+++ b/src/addon/event-listeners/DirectoryEventListener.mm
@@ -3,78 +3,97 @@
 
 using namespace syphon;
 
-DirectoryEventListener::DirectoryEventListener() {
-    m_listener = NULL;
-}
+DirectoryEventListener::DirectoryEventListener() { m_listener = NULL; }
 
 void DirectoryEventListener::Set(Napi::Env env, Napi::Function listener) {
-    m_listener = Napi::ThreadSafeFunction::New(
-        env,
-        listener, 
-        "Directory Event Listener",
-        0,
-        1
-    );
+  m_listener = Napi::ThreadSafeFunction::New(env, listener,
+                                             "Directory Event Listener", 0, 1);
 }
 
-DirectoryEventListener::~DirectoryEventListener()
-{
-    if (m_listener != NULL) {
-        m_listener.Release(); 
-        m_listener = NULL;
-    }
+DirectoryEventListener::~DirectoryEventListener() {
+  if (m_listener != NULL) {
+    m_listener.Release();
+    m_listener = NULL;
+  }
 }
 
-void DirectoryEventListener::Dispose()
-{
-    if (m_listener != NULL) {
-        m_listener.Release(); 
-        m_listener = NULL;
-    }
+void DirectoryEventListener::Dispose() {
+  if (m_listener != NULL) {
+    m_listener.Release();
+    m_listener = NULL;
+  }
 }
 
-void DirectoryEventListener::Call(NSDictionary * dictionary) {
-    if (m_listener != NULL) {
-        printf("Class with userInfo!\n");
-        auto callback = [dictionary](Napi::Env env, Napi::Function js_callback) {
+void DirectoryEventListener::Call(NSDictionary *dictionary) {
+  if (m_listener != NULL) {
+    printf("Class with userInfo!\n");
+    auto callback = [dictionary](Napi::Env env, Napi::Function js_callback) {
+      Napi::Object obj = Napi::Object::New(env);
 
-            Napi::Object obj = Napi::Object::New(env);
+      if ([dictionary objectForKey:SyphonServerDescriptionNameKey]) {
+        obj.Set(
+            "SyphonServerDescriptionNameKey",
+            Napi::String::New(
+                env, [[dictionary objectForKey:SyphonServerDescriptionNameKey]
+                         UTF8String]));
+      }
 
-            if ([dictionary objectForKey:SyphonServerDescriptionNameKey]) {
-                obj.Set("SyphonServerDescriptionNameKey", Napi::String::New(env, [[dictionary objectForKey:SyphonServerDescriptionNameKey] UTF8String]));
-            }
+      if ([dictionary objectForKey:SyphonServerDescriptionAppNameKey]) {
+        obj.Set("SyphonServerDescriptionAppNameKey",
+                Napi::String::New(
+                    env,
+                    [[dictionary objectForKey:SyphonServerDescriptionAppNameKey]
+                        UTF8String]));
+      }
 
-            if ([dictionary objectForKey:SyphonServerDescriptionAppNameKey]) {
-                obj.Set("SyphonServerDescriptionAppNameKey", Napi::String::New(env, [[dictionary objectForKey:SyphonServerDescriptionAppNameKey] UTF8String]));
-            }
+      if ([dictionary objectForKey:SyphonServerDescriptionUUIDKey]) {
+        obj.Set(
+            "SyphonServerDescriptionUUIDKey",
+            Napi::String::New(
+                env, [[dictionary objectForKey:SyphonServerDescriptionUUIDKey]
+                         UTF8String]));
+      }
 
-            if ([dictionary objectForKey:SyphonServerDescriptionUUIDKey]) {
-                obj.Set("SyphonServerDescriptionUUIDKey", Napi::String::New(env, [[dictionary objectForKey:SyphonServerDescriptionUUIDKey] UTF8String]));
-            }
+      if ([dictionary
+              objectForKey:@"SyphonServerDescriptionDictionaryVersionKey"]) {
+        obj.Set(
+            "SyphonServerDescriptionDictionaryVersionKey",
+            Napi::Number::New(
+                env,
+                [[dictionary
+                    objectForKey:@"SyphonServerDescriptionDictionaryVersionKey"]
+                    intValue]));
+      }
 
-            if ([dictionary objectForKey:@"SyphonServerDescriptionDictionaryVersionKey"]) {
-                obj.Set("SyphonServerDescriptionDictionaryVersionKey",  Napi::Number::New(env, [[dictionary objectForKey:@"SyphonServerDescriptionDictionaryVersionKey"] intValue]));
-            }
+      if ([dictionary objectForKey:@"SyphonServerDescriptionSurfacesKey"]) {
+        Napi::Array arr = Napi::Array::New(
+            env,
+            [[dictionary objectForKey:@"SyphonServerDescriptionSurfacesKey"]
+                length]);
 
-            if ([dictionary objectForKey:@"SyphonServerDescriptionSurfacesKey"]) {
-                Napi::Array arr = Napi::Array::New(env, [[dictionary objectForKey:@"SyphonServerDescriptionSurfacesKey"] length]);
+        for (NSUInteger i = 0;
+             i <
+             [[dictionary
+                 objectForKey:@"SyphonServerDescriptionSurfacesKey"] length];
+             i++) {
+          NSDictionary *surface_dic = [dictionary
+              objectForKey:@"SyphonServerDescriptionSurfacesKey"][i];
 
-                for (NSUInteger i = 0; i < [[dictionary objectForKey:@"SyphonServerDescriptionSurfacesKey"] length]; i++) {
-                    NSDictionary * surface_dic = [dictionary objectForKey:@"SyphonServerDescriptionSurfacesKey"][i];
+          Napi::Object surface_description = Napi::Object::New(env);
+          surface_description.Set(
+              "SyphonSurfaceType",
+              Napi::String::New(
+                  env, [surface_dic[@"SyphonSurfaceType"] UTF8String]));
 
-                    Napi::Object surface_description = Napi::Object::New(env);
-                    surface_description.Set("SyphonSurfaceType", Napi::String::New(env, [surface_dic[@"SyphonSurfaceType"] UTF8String]));
+          arr.Set(i, surface_description);
+        }
 
-                    arr.Set(i, surface_description);
-                }
+        obj.Set("SyphonServerDescriptionSurfacesKey", arr);
+      }
 
-                obj.Set("SyphonServerDescriptionSurfacesKey",  arr);
-            }
+      js_callback.Call({obj});
+    };
 
-            js_callback.Call({ obj });
-
-        };
-
-        m_listener.NonBlockingCall(callback); 
-    }
+    m_listener.NonBlockingCall(callback);
+  }
 }

--- a/src/addon/event-listeners/FrameEventListener.h
+++ b/src/addon/event-listeners/FrameEventListener.h
@@ -3,23 +3,21 @@
 
 #include <napi.h>
 
-namespace syphon
-{
+namespace syphon {
 
-  class FrameEventListener
-  {
-    public:
-        FrameEventListener();
-        ~FrameEventListener();
+class FrameEventListener {
+public:
+  FrameEventListener();
+  ~FrameEventListener();
 
-        void Dispose();
+  void Dispose();
 
-        void Set(Napi::Env env, Napi::Function listener);
-        void Call(uint8_t * buffer, size_t width, size_t height);
+  void Set(Napi::Env env, Napi::Function listener);
+  void Call(uint8_t *buffer, size_t width, size_t height);
 
-    private:
-      Napi::ThreadSafeFunction m_listener;
-  };
-}
+private:
+  Napi::ThreadSafeFunction m_listener;
+};
+} // namespace syphon
 
 #endif

--- a/src/addon/event-listeners/FrameEventListener.mm
+++ b/src/addon/event-listeners/FrameEventListener.mm
@@ -3,55 +3,45 @@
 
 using namespace syphon;
 
-FrameEventListener::FrameEventListener() {
-    m_listener = NULL;
-}
+FrameEventListener::FrameEventListener() { m_listener = NULL; }
 
 void FrameEventListener::Set(Napi::Env env, Napi::Function listener) {
-    m_listener = Napi::ThreadSafeFunction::New(
-        env,
-        listener, 
-        "Frame Event Listener",
-        0,
-        1
-    );
+  m_listener = Napi::ThreadSafeFunction::New(env, listener,
+                                             "Frame Event Listener", 0, 1);
 }
 
-FrameEventListener::~FrameEventListener()
-{
-    if (m_listener != NULL) {
-        m_listener.Release(); 
-        m_listener = NULL;
-    }
+FrameEventListener::~FrameEventListener() {
+  if (m_listener != NULL) {
+    m_listener.Release();
+    m_listener = NULL;
+  }
 }
 
-void FrameEventListener::Dispose()
-{
-    if (m_listener != NULL) {
-        m_listener.Release(); 
-        m_listener = NULL;
-    }
+void FrameEventListener::Dispose() {
+  if (m_listener != NULL) {
+    m_listener.Release();
+    m_listener = NULL;
+  }
 }
 
-void FrameEventListener::Call(uint8_t * buffer, size_t width, size_t height) {
-    if (m_listener != NULL) {
-        auto callback = [buffer, width, height](Napi::Env env, Napi::Function js_callback) {
+void FrameEventListener::Call(uint8_t *buffer, size_t width, size_t height) {
+  if (m_listener != NULL) {
+    auto callback = [buffer, width, height](Napi::Env env,
+                                            Napi::Function js_callback) {
+      auto napi_buffer = Napi::Buffer<uint8_t>::NewOrCopy(
+          env, buffer, width * height * 4,
+          [](Napi::BasicEnv, void *finalizeData) {
+            delete[] static_cast<uint8_t *>(finalizeData);
+          });
 
-            auto napi_buffer = Napi::Buffer<uint8_t>::NewOrCopy(env, buffer, width * height * 4, [](Napi::BasicEnv, void* finalizeData) {
+      Napi::Object obj = Napi::Object::New(env);
+      obj.Set("buffer", napi_buffer);
+      obj.Set("width", Napi::Number::New(env, width));
+      obj.Set("height", Napi::Number::New(env, height));
 
-                delete[] static_cast<uint8_t *>(finalizeData);
+      js_callback.Call({obj});
+    };
 
-            });
-
-            Napi::Object obj = Napi::Object::New(env);
-            obj.Set("buffer", napi_buffer);
-            obj.Set("width", Napi::Number::New(env, width));
-            obj.Set("height", Napi::Number::New(env, height));
-
-            js_callback.Call({ obj });
-
-        };
-
-        m_listener.NonBlockingCall(callback); // Was BlockingCall
-    }
+    m_listener.NonBlockingCall(callback); // Was BlockingCall
+  }
 }

--- a/src/addon/event-listeners/StringEventListener.h
+++ b/src/addon/event-listeners/StringEventListener.h
@@ -1,27 +1,25 @@
 #ifndef __STRING_EVENT_LISTENER_H__
 #define __STRING_EVENT_LISTENER_H__
 
-#include <napi.h>
-#include <Foundation/Foundation.h>
 #include <Cocoa/Cocoa.h>
+#include <Foundation/Foundation.h>
+#include <napi.h>
 
-namespace syphon
-{
+namespace syphon {
 
-  class StringEventListener
-  {
-    public:
-        StringEventListener();
-        ~StringEventListener();
+class StringEventListener {
+public:
+  StringEventListener();
+  ~StringEventListener();
 
-        void Dispose();
+  void Dispose();
 
-        void Set(Napi::Env env, Napi::Function listener);
-        void Call(std::string str);
+  void Set(Napi::Env env, Napi::Function listener);
+  void Call(std::string str);
 
-    private:
-      Napi::ThreadSafeFunction m_listener;
-  };
-}
+private:
+  Napi::ThreadSafeFunction m_listener;
+};
+} // namespace syphon
 
 #endif

--- a/src/addon/event-listeners/StringEventListener.mm
+++ b/src/addon/event-listeners/StringEventListener.mm
@@ -3,46 +3,35 @@
 
 using namespace syphon;
 
-StringEventListener::StringEventListener() {
-    m_listener = NULL;
-}
+StringEventListener::StringEventListener() { m_listener = NULL; }
 
 void StringEventListener::Set(Napi::Env env, Napi::Function listener) {
-    m_listener = Napi::ThreadSafeFunction::New(
-        env,
-        listener, 
-        "String Event Listener",
-        0,
-        1
-    );
+  m_listener = Napi::ThreadSafeFunction::New(env, listener,
+                                             "String Event Listener", 0, 1);
 }
 
-StringEventListener::~StringEventListener()
-{
-    if (m_listener != NULL) {
-        m_listener.Release(); 
-        m_listener = NULL;
-    }
+StringEventListener::~StringEventListener() {
+  if (m_listener != NULL) {
+    m_listener.Release();
+    m_listener = NULL;
+  }
 }
 
-void StringEventListener::Dispose()
-{
-    if (m_listener != NULL) {
-        m_listener.Release(); 
-        m_listener = NULL;
-    }
+void StringEventListener::Dispose() {
+  if (m_listener != NULL) {
+    m_listener.Release();
+    m_listener = NULL;
+  }
 }
 
 void StringEventListener::Call(std::string str) {
-    if (m_listener != NULL) {
-        printf("Emit Info\n");
-        auto callback = [str](Napi::Env env, Napi::Function js_callback) {
+  if (m_listener != NULL) {
+    printf("Emit Info\n");
+    auto callback = [str](Napi::Env env, Napi::Function js_callback) {
+      Napi::String result = Napi::String::New(env, str);
+      js_callback.Call({result});
+    };
 
-            Napi::String result = Napi::String::New(env, str);
-            js_callback.Call({ result });
-
-        };
-
-        m_listener.NonBlockingCall(callback); 
-    }
+    m_listener.NonBlockingCall(callback);
+  }
 }

--- a/src/addon/event-listeners/TextureEventListener.h
+++ b/src/addon/event-listeners/TextureEventListener.h
@@ -1,0 +1,26 @@
+#ifndef __TEXTURE_EVENT_LISTENER_H__
+#define __TEXTURE_EVENT_LISTENER_H__
+
+#include <napi.h>
+#include <IOSurface/IOSurface.h>
+
+namespace syphon
+{
+
+  class TextureEventListener
+  {
+    public:
+        TextureEventListener();
+        ~TextureEventListener();
+
+        void Dispose();
+
+        void Set(Napi::Env env, Napi::Function listener);
+        void Call(uint8_t * buffer, size_t width, size_t height);
+
+    private:
+      Napi::ThreadSafeFunction m_listener;
+  };
+}
+
+#endif

--- a/src/addon/event-listeners/TextureEventListener.h
+++ b/src/addon/event-listeners/TextureEventListener.h
@@ -14,7 +14,11 @@ public:
   void Dispose();
 
   void Set(Napi::Env env, Napi::Function listener);
-  void Call(uint8_t *buffer, size_t width, size_t height);
+  void Call(uint8_t *buffer, size_t width, size_t height,
+            std::string pixel_format, unsigned long frame_count,
+            long long time_elapsed);
+
+  void Test(const Napi::CallbackInfo &info);
 
 private:
   Napi::ThreadSafeFunction m_listener;

--- a/src/addon/event-listeners/TextureEventListener.h
+++ b/src/addon/event-listeners/TextureEventListener.h
@@ -1,26 +1,24 @@
 #ifndef __TEXTURE_EVENT_LISTENER_H__
 #define __TEXTURE_EVENT_LISTENER_H__
 
-#include <napi.h>
 #include <IOSurface/IOSurface.h>
+#include <napi.h>
 
-namespace syphon
-{
+namespace syphon {
 
-  class TextureEventListener
-  {
-    public:
-        TextureEventListener();
-        ~TextureEventListener();
+class TextureEventListener {
+public:
+  TextureEventListener();
+  ~TextureEventListener();
 
-        void Dispose();
+  void Dispose();
 
-        void Set(Napi::Env env, Napi::Function listener);
-        void Call(uint8_t * buffer, size_t width, size_t height);
+  void Set(Napi::Env env, Napi::Function listener);
+  void Call(uint8_t *buffer, size_t width, size_t height);
 
-    private:
-      Napi::ThreadSafeFunction m_listener;
-  };
-}
+private:
+  Napi::ThreadSafeFunction m_listener;
+};
+} // namespace syphon
 
 #endif

--- a/src/addon/event-listeners/TextureEventListener.mm
+++ b/src/addon/event-listeners/TextureEventListener.mm
@@ -3,55 +3,46 @@
 
 using namespace syphon;
 
-TextureEventListener::TextureEventListener() {
-    m_listener = NULL;
-}
+TextureEventListener::TextureEventListener() { m_listener = NULL; }
 
 void TextureEventListener::Set(Napi::Env env, Napi::Function listener) {
-    m_listener = Napi::ThreadSafeFunction::New(
-        env,
-        listener, 
-        "Texture Event Listener",
-        0,
-        1
-    );
+  m_listener = Napi::ThreadSafeFunction::New(env, listener,
+                                             "Texture Event Listener", 0, 1);
 }
 
-TextureEventListener::~TextureEventListener()
-{
-    if (m_listener != NULL) {
-        m_listener.Release(); 
-        m_listener = NULL;
-    }
+TextureEventListener::~TextureEventListener() {
+  if (m_listener != NULL) {
+    m_listener.Release();
+    m_listener = NULL;
+  }
 }
 
-void TextureEventListener::Dispose()
-{
-    if (m_listener != NULL) {
-        m_listener.Release(); 
-        m_listener = NULL;
-    }
+void TextureEventListener::Dispose() {
+  if (m_listener != NULL) {
+    m_listener.Release();
+    m_listener = NULL;
+  }
 }
 
-void TextureEventListener::Call(uint8_t * surface, size_t width, size_t height) {
-    if (m_listener != NULL) {
-        auto callback = [surface, width, height](Napi::Env env, Napi::Function js_callback) {
+void TextureEventListener::Call(uint8_t *surface, size_t width, size_t height) {
+  if (m_listener != NULL) {
+    auto callback = [surface, width, height](Napi::Env env,
+                                             Napi::Function js_callback) {
+      auto napi_buffer = Napi::Buffer<uint8_t>::NewOrCopy(
+          env,
+          const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(&surface)),
+          sizeof(IOSurfaceRef), [](Napi::BasicEnv, void *finalizeData) {
+            // delete[] static_cast<uint8_t *>(finalizeData);
+          });
 
-            auto napi_buffer = Napi::Buffer<uint8_t>::NewOrCopy(env, const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(&surface)), sizeof(IOSurfaceRef), [](Napi::BasicEnv, void* finalizeData) {
+      Napi::Object obj = Napi::Object::New(env);
+      obj.Set("surface", napi_buffer);
+      obj.Set("width", Napi::Number::New(env, width));
+      obj.Set("height", Napi::Number::New(env, height));
 
-                // delete[] static_cast<uint8_t *>(finalizeData);
+      js_callback.Call({obj});
+    };
 
-            });
-
-            Napi::Object obj = Napi::Object::New(env);
-            obj.Set("surface", napi_buffer);
-            obj.Set("width", Napi::Number::New(env, width));
-            obj.Set("height", Napi::Number::New(env, height));
-
-            js_callback.Call({ obj });
-
-        };
-
-        m_listener.NonBlockingCall(callback); // Was BlockingCall
-    }
+    m_listener.NonBlockingCall(callback); // Was BlockingCall
+  }
 }

--- a/src/addon/event-listeners/TextureEventListener.mm
+++ b/src/addon/event-listeners/TextureEventListener.mm
@@ -24,10 +24,14 @@ void TextureEventListener::Dispose() {
   }
 }
 
-void TextureEventListener::Call(uint8_t *surface, size_t width, size_t height) {
+void TextureEventListener::Call(uint8_t *surface, size_t width, size_t height,
+                                std::string pixel_format,
+                                unsigned long frame_count,
+                                long long time_elapsed) {
   if (m_listener != NULL) {
-    auto callback = [surface, width, height](Napi::Env env,
-                                             Napi::Function js_callback) {
+
+    auto callback = [surface, pixel_format, width, height, frame_count,
+                     time_elapsed](Napi::Env env, Napi::Function js_callback) {
       auto napi_buffer = Napi::Buffer<uint8_t>::NewOrCopy(
           env,
           const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(&surface)),
@@ -39,10 +43,13 @@ void TextureEventListener::Call(uint8_t *surface, size_t width, size_t height) {
       obj.Set("surface", napi_buffer);
       obj.Set("width", Napi::Number::New(env, width));
       obj.Set("height", Napi::Number::New(env, height));
+      obj.Set("pixelFormat", Napi::String::New(env, pixel_format));
+      obj.Set("frameCount", Napi::Number::New(env, frame_count));
+      obj.Set("timestamp", Napi::Number::New(env, time_elapsed));
 
       js_callback.Call({obj});
     };
 
-    m_listener.NonBlockingCall(callback); // Was BlockingCall
+    m_listener.NonBlockingCall(callback);
   }
 }

--- a/src/addon/event-listeners/TextureEventListener.mm
+++ b/src/addon/event-listeners/TextureEventListener.mm
@@ -32,12 +32,10 @@ void TextureEventListener::Call(uint8_t *surface, size_t width, size_t height,
 
     auto callback = [surface, pixel_format, width, height, frame_count,
                      time_elapsed](Napi::Env env, Napi::Function js_callback) {
-      auto napi_buffer = Napi::Buffer<uint8_t>::NewOrCopy(
+      auto napi_buffer = Napi::Buffer<uint8_t>::Copy(
           env,
-          const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(&surface)),
-          sizeof(IOSurfaceRef), [](Napi::BasicEnv, void *finalizeData) {
-            // delete[] static_cast<uint8_t *>(finalizeData);
-          });
+          reinterpret_cast<const uint8_t*>(&surface),
+          sizeof(IOSurfaceRef));
 
       Napi::Object obj = Napi::Object::New(env);
       obj.Set("surface", napi_buffer);

--- a/src/addon/event-listeners/TextureEventListener.mm
+++ b/src/addon/event-listeners/TextureEventListener.mm
@@ -1,0 +1,57 @@
+#include "TextureEventListener.h"
+#include "../helpers/macros.h"
+
+using namespace syphon;
+
+TextureEventListener::TextureEventListener() {
+    m_listener = NULL;
+}
+
+void TextureEventListener::Set(Napi::Env env, Napi::Function listener) {
+    m_listener = Napi::ThreadSafeFunction::New(
+        env,
+        listener, 
+        "Texture Event Listener",
+        0,
+        1
+    );
+}
+
+TextureEventListener::~TextureEventListener()
+{
+    if (m_listener != NULL) {
+        m_listener.Release(); 
+        m_listener = NULL;
+    }
+}
+
+void TextureEventListener::Dispose()
+{
+    if (m_listener != NULL) {
+        m_listener.Release(); 
+        m_listener = NULL;
+    }
+}
+
+void TextureEventListener::Call(uint8_t * surface, size_t width, size_t height) {
+    if (m_listener != NULL) {
+        auto callback = [surface, width, height](Napi::Env env, Napi::Function js_callback) {
+
+            auto napi_buffer = Napi::Buffer<uint8_t>::NewOrCopy(env, const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(&surface)), sizeof(IOSurfaceRef), [](Napi::BasicEnv, void* finalizeData) {
+
+                // delete[] static_cast<uint8_t *>(finalizeData);
+
+            });
+
+            Napi::Object obj = Napi::Object::New(env);
+            obj.Set("surface", napi_buffer);
+            obj.Set("width", Napi::Number::New(env, width));
+            obj.Set("height", Napi::Number::New(env, height));
+
+            js_callback.Call({ obj });
+
+        };
+
+        m_listener.NonBlockingCall(callback); // Was BlockingCall
+    }
+}

--- a/src/addon/helpers/ServerDescriptionHelper.h
+++ b/src/addon/helpers/ServerDescriptionHelper.h
@@ -1,18 +1,18 @@
 #ifndef __SERVER_DESCRIPTION_HELPER_H__
 #define __SERVER_DESCRIPTION_HELPER_H__
 
-#include <napi.h>
-#include <Foundation/Foundation.h>
 #include <Cocoa/Cocoa.h>
+#include <Foundation/Foundation.h>
 #include <Syphon/Syphon.h>
+#include <napi.h>
 
-namespace syphon
-{
-  class ServerDescriptionHelper : public Napi::ObjectWrap<ServerDescriptionHelper>
-  {
-    public:
-      static Napi::Object ToNapiObject(NSDictionary * serverDescription, const Napi::CallbackInfo & info);
-      static NSDictionary * FromNapiObject(Napi::Object serverDescription);
-  };
-}
+namespace syphon {
+class ServerDescriptionHelper
+    : public Napi::ObjectWrap<ServerDescriptionHelper> {
+public:
+  static Napi::Object ToNapiObject(NSDictionary *serverDescription,
+                                   const Napi::CallbackInfo &info);
+  static NSDictionary *FromNapiObject(Napi::Object serverDescription);
+};
+} // namespace syphon
 #endif

--- a/src/addon/helpers/ServerDescriptionHelper.mm
+++ b/src/addon/helpers/ServerDescriptionHelper.mm
@@ -2,38 +2,74 @@
 
 using namespace syphon;
 
-Napi::Object ServerDescriptionHelper::ToNapiObject(NSDictionary * serverDescription, const Napi::CallbackInfo & info)
-{
+Napi::Object
+ServerDescriptionHelper::ToNapiObject(NSDictionary *serverDescription,
+                                      const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
   Napi::HandleScope scope(env);
 
   Napi::Object obj = Napi::Object::New(env);
 
   if ([serverDescription objectForKey:SyphonServerDescriptionNameKey])
-    obj.Set("SyphonServerDescriptionNameKey", [[serverDescription objectForKey:SyphonServerDescriptionNameKey] UTF8String]);
+    obj.Set("SyphonServerDescriptionNameKey",
+            [[serverDescription objectForKey:SyphonServerDescriptionNameKey]
+                UTF8String]);
 
   if ([serverDescription objectForKey:SyphonServerDescriptionAppNameKey])
-    obj.Set("SyphonServerDescriptionAppNameKey", [[serverDescription objectForKey:SyphonServerDescriptionAppNameKey] UTF8String]);
+    obj.Set("SyphonServerDescriptionAppNameKey",
+            [[serverDescription objectForKey:SyphonServerDescriptionAppNameKey]
+                UTF8String]);
 
   if ([serverDescription objectForKey:SyphonServerDescriptionUUIDKey])
-    obj.Set("SyphonServerDescriptionUUIDKey", [[serverDescription objectForKey:SyphonServerDescriptionUUIDKey] UTF8String]);
+    obj.Set("SyphonServerDescriptionUUIDKey",
+            [[serverDescription objectForKey:SyphonServerDescriptionUUIDKey]
+                UTF8String]);
 
   return obj;
 }
 
-NSDictionary * ServerDescriptionHelper::FromNapiObject(Napi::Object serverDescription)
-{
-  NSMutableDictionary * dictionary = [[NSMutableDictionary alloc] init];
-  [dictionary setObject:[NSString stringWithUTF8String:serverDescription.Get("SyphonServerDescriptionAppNameKey").As<Napi::String>().Utf8Value().c_str()] forKey:SyphonServerDescriptionAppNameKey];
-  [dictionary setObject:[NSString stringWithUTF8String:serverDescription.Get("SyphonServerDescriptionNameKey").As<Napi::String>().Utf8Value().c_str()] forKey:SyphonServerDescriptionNameKey];
-  [dictionary setObject:[NSString stringWithUTF8String:serverDescription.Get("SyphonServerDescriptionUUIDKey").As<Napi::String>().Utf8Value().c_str()] forKey:SyphonServerDescriptionUUIDKey];
-  [dictionary setObject:[NSNumber numberWithUnsignedInt:serverDescription.Get("SyphonServerDescriptionDictionaryVersionKey").As<Napi::Number>().Uint32Value()] forKey:@"SyphonServerDescriptionDictionaryVersionKey"];
+NSDictionary *
+ServerDescriptionHelper::FromNapiObject(Napi::Object serverDescription) {
+  NSMutableDictionary *dictionary = [[NSMutableDictionary alloc] init];
+  [dictionary
+      setObject:[NSString stringWithUTF8String:
+                              serverDescription
+                                  .Get("SyphonServerDescriptionAppNameKey")
+                                  .As<Napi::String>()
+                                  .Utf8Value()
+                                  .c_str()]
+         forKey:SyphonServerDescriptionAppNameKey];
+  [dictionary setObject:[NSString stringWithUTF8String:
+                                      serverDescription
+                                          .Get("SyphonServerDescriptionNameKey")
+                                          .As<Napi::String>()
+                                          .Utf8Value()
+                                          .c_str()]
+                 forKey:SyphonServerDescriptionNameKey];
+  [dictionary setObject:[NSString stringWithUTF8String:
+                                      serverDescription
+                                          .Get("SyphonServerDescriptionUUIDKey")
+                                          .As<Napi::String>()
+                                          .Utf8Value()
+                                          .c_str()]
+                 forKey:SyphonServerDescriptionUUIDKey];
+  [dictionary
+      setObject:[NSNumber
+                    numberWithUnsignedInt:
+                        serverDescription
+                            .Get("SyphonServerDescriptionDictionaryVersionKey")
+                            .As<Napi::Number>()
+                            .Uint32Value()]
+         forKey:@"SyphonServerDescriptionDictionaryVersionKey"];
 
   // TODO: Get from description itself.
-  NSDictionary *surfaces = [NSDictionary dictionaryWithObjectsAndKeys: @"SyphonSurfaceTypeIOSurface", @"SyphonSurfaceType", nil];
-  [dictionary setObject:[NSArray arrayWithObject:surfaces] forKey:@"SyphonServerDescriptionSurfacesKey"];
+  NSDictionary *surfaces =
+      [NSDictionary dictionaryWithObjectsAndKeys:@"SyphonSurfaceTypeIOSurface",
+                                                 @"SyphonSurfaceType", nil];
+  [dictionary setObject:[NSArray arrayWithObject:surfaces]
+                 forKey:@"SyphonServerDescriptionSurfacesKey"];
 
-  NSDictionary * copy = [dictionary copy];
+  NSDictionary *copy = [dictionary copy];
   [dictionary release];
 
   return copy;

--- a/src/addon/helpers/macros.h
+++ b/src/addon/helpers/macros.h
@@ -3,25 +3,35 @@
 
 #pragma mark Checks
 
-#define IS_POINT(value) (value.IsObject() && value.As<Napi::Object>().Has("x") && value.As<Napi::Object>().Has("y"))
+#define IS_POINT(value)                                                        \
+  (value.IsObject() && value.As<Napi::Object>().Has("x") &&                    \
+   value.As<Napi::Object>().Has("y"))
 
-#define IS_SIZE(value) (value.IsObject() && value.As<Napi::Object>().Has("width") && value.As<Napi::Object>().Has("height"))
+#define IS_SIZE(value)                                                         \
+  (value.IsObject() && value.As<Napi::Object>().Has("width") &&                \
+   value.As<Napi::Object>().Has("height"))
 
 #define IS_RECT(value) (IS_POINT(value) && IS_SIZE(value))
 
-#define IS_UINT8_CLAMPED_ARRAY(value) (value.IsTypedArray() && value.As<Napi::TypedArray>().TypedArrayType() == napi_uint8_clamped_array)
+#define IS_UINT8_CLAMPED_ARRAY(value)                                          \
+  (value.IsTypedArray() &&                                                     \
+   value.As<Napi::TypedArray>().TypedArrayType() == napi_uint8_clamped_array)
 
 #define IS_NUMBER(value) (value.IsNumber())
 
 #define IS_BUFFER(value) (value.IsBuffer())
 
-#define IS_TEXTURE_TARGET(value) (value.IsString() && (value.As<Napi::String>().Utf8Value() == "GL_TEXTURE_RECTANGLE_EXT" || value.As<Napi::String>().Utf8Value() == "GL_TEXTURE_2D"))
+#define IS_TEXTURE_TARGET(value)                                               \
+  (value.IsString() &&                                                         \
+   (value.As<Napi::String>().Utf8Value() == "GL_TEXTURE_RECTANGLE_EXT" ||      \
+    value.As<Napi::String>().Utf8Value() == "GL_TEXTURE_2D"))
 
-#define IS_SERVER_DESCRIPTION(value) value.Has("SyphonServerDescriptionAppNameKey") && \
-                                     value.Has("SyphonServerDescriptionNameKey") && \
-                                     value.Has("SyphonServerDescriptionUUIDKey") && \
-                                     value.Has("SyphonServerDescriptionDictionaryVersionKey") && \
-                                     value.Has("SyphonServerDescriptionSurfacesKey")
+#define IS_SERVER_DESCRIPTION(value)                                           \
+  value.Has("SyphonServerDescriptionAppNameKey") &&                            \
+      value.Has("SyphonServerDescriptionNameKey") &&                           \
+      value.Has("SyphonServerDescriptionUUIDKey") &&                           \
+      value.Has("SyphonServerDescriptionDictionaryVersionKey") &&              \
+      value.Has("SyphonServerDescriptionSurfacesKey")
 
 #pragma mark Converters
 

--- a/src/addon/main.h
+++ b/src/addon/main.h
@@ -1,10 +1,10 @@
 #ifndef ___NODE_SYPHON_H___
 #define ___NODE_SYPHON_H___
 
-#include "opengl/OpenGLServer.h"
-#include "opengl/OpenGLClient.h"
-#include "metal/MetalServer.h"
-#include "metal/MetalClient.h"
 #include "directory/ServerDirectory.h"
+#include "metal/MetalClient.h"
+#include "metal/MetalServer.h"
+#include "opengl/OpenGLClient.h"
+#include "opengl/OpenGLServer.h"
 
 #endif

--- a/src/addon/main.mm
+++ b/src/addon/main.mm
@@ -1,10 +1,9 @@
-#include <napi.h>
 #include "main.h"
+#include <napi.h>
 
 using namespace syphon;
 
-Napi::Object InitAll(Napi::Env env, Napi::Object exports)
-{
+Napi::Object InitAll(Napi::Env env, Napi::Object exports) {
   OpenGLServerWrapper::Init(env, exports);
   OpenGLClientWrapper::Init(env, exports);
   MetalServerWrapper::Init(env, exports);

--- a/src/addon/metal/MetalClient.h
+++ b/src/addon/metal/MetalClient.h
@@ -36,6 +36,7 @@ public:
 
 private:
   static Napi::FunctionReference constructor;
+  void CleanupTextures();
 
   SyphonMetalClient *m_client;
   id<MTLDevice> m_device;

--- a/src/addon/metal/MetalClient.h
+++ b/src/addon/metal/MetalClient.h
@@ -1,42 +1,45 @@
 #ifndef ___METAL_CLIENT_H___
 #define ___METAL_CLIENT_H___
 
-#include <napi.h>
 #include <Foundation/Foundation.h>
+#include <napi.h>
 // #include <Cocoa/Cocoa.h>
-#include <Syphon/Syphon.h>
-#include <Metal/Metal.h>
-#include <Accelerate/Accelerate.h>
-#include "../helpers/macros.h"
 #include "../event-listeners/FrameEventListener.h"
 #include "../event-listeners/TextureEventListener.h"
+#include "../helpers/macros.h"
+#include <Accelerate/Accelerate.h>
+#include <Metal/Metal.h>
+#include <Syphon/Syphon.h>
 
-namespace syphon
-{
+namespace syphon {
 
-  class MetalClientWrapper : public Napi::ObjectWrap<MetalClientWrapper>
-  {
+class MetalClientWrapper : public Napi::ObjectWrap<MetalClientWrapper> {
 
-  public:
-    static Napi::Object Init(Napi::Env env, Napi::Object exports);
-    static bool HasInstance(Napi::Value value);
+public:
+  static Napi::Object Init(Napi::Env env, Napi::Object exports);
+  static bool HasInstance(Napi::Value value);
 
-    MetalClientWrapper(const Napi::CallbackInfo &info);
-    ~MetalClientWrapper();
+  MetalClientWrapper(const Napi::CallbackInfo &info);
+  ~MetalClientWrapper();
 
-    void Dispose(const Napi::CallbackInfo &info);
-    void On(const Napi::CallbackInfo &info);
-    void Off(const Napi::CallbackInfo &info);
+  void Dispose(const Napi::CallbackInfo &info);
+  void On(const Napi::CallbackInfo &info);
+  void Off(const Napi::CallbackInfo &info);
 
-  private:
-    static Napi::FunctionReference constructor;
+  int GetUniqueId() {
+    static std::atomic<int> next_id(1);
+    return ++next_id;
+  }
 
-    SyphonMetalClient * m_client;
-    id<MTLDevice> m_device;
-    id<MTLCommandQueue> m_queue;
-    FrameEventListener * m_frame_listener;
-    TextureEventListener * m_texture_listener;
-  };
-}
+private:
+  static Napi::FunctionReference constructor;
+
+  SyphonMetalClient *m_client;
+  id<MTLDevice> m_device;
+  id<MTLCommandQueue> m_queue;
+  FrameEventListener *m_frame_listener;
+  TextureEventListener *m_texture_listener;
+};
+} // namespace syphon
 
 #endif

--- a/src/addon/metal/MetalClient.h
+++ b/src/addon/metal/MetalClient.h
@@ -2,7 +2,9 @@
 #define ___METAL_CLIENT_H___
 
 #include <Foundation/Foundation.h>
+#include <map>
 #include <napi.h>
+#include <utility>
 // #include <Cocoa/Cocoa.h>
 #include "../event-listeners/FrameEventListener.h"
 #include "../event-listeners/TextureEventListener.h"
@@ -25,10 +27,11 @@ public:
   void Dispose(const Napi::CallbackInfo &info);
   void On(const Napi::CallbackInfo &info);
   void Off(const Napi::CallbackInfo &info);
+  void ReleaseTexture(const Napi::CallbackInfo &info);
 
-  int GetUniqueId() {
-    static std::atomic<int> next_id(1);
-    return ++next_id;
+  unsigned long GetFrameCount() {
+    static std::atomic<unsigned long> next_frame(1);
+    return ++next_frame;
   }
 
 private:
@@ -38,7 +41,9 @@ private:
   id<MTLDevice> m_device;
   id<MTLCommandQueue> m_queue;
   FrameEventListener *m_frame_listener;
+
   TextureEventListener *m_texture_listener;
+  std::map<unsigned long, id<MTLTexture>> m_textures;
 };
 } // namespace syphon
 

--- a/src/addon/metal/MetalClient.h
+++ b/src/addon/metal/MetalClient.h
@@ -9,6 +9,7 @@
 #include <Accelerate/Accelerate.h>
 #include "../helpers/macros.h"
 #include "../event-listeners/FrameEventListener.h"
+#include "../event-listeners/TextureEventListener.h"
 
 namespace syphon
 {
@@ -34,6 +35,7 @@ namespace syphon
     id<MTLDevice> m_device;
     id<MTLCommandQueue> m_queue;
     FrameEventListener * m_frame_listener;
+    TextureEventListener * m_texture_listener;
   };
 }
 

--- a/src/addon/metal/MetalClient.mm
+++ b/src/addon/metal/MetalClient.mm
@@ -95,7 +95,8 @@ MetalClientWrapper::MetalClientWrapper(const Napi::CallbackInfo &info)
                           (__bridge CFDictionaryRef)surfaceProps);
 
                       if (!new_surface) {
-                        Napi::TypeError::New(env, "IOSurfaceCreate failed").ThrowAsJavaScriptException();
+                        NSLog(@"[MetalClient] IOSurfaceCreate failed (%zu×%zu)", width, height);
+                        return;
                       }
 
                       // Wrap the surface in a Metal texture

--- a/src/addon/metal/MetalClient.mm
+++ b/src/addon/metal/MetalClient.mm
@@ -101,6 +101,7 @@ MetalClientWrapper::MetalClientWrapper(const Napi::CallbackInfo &info)
                                                       height:height
                                                    mipmapped:NO];
 
+                      desc.storageMode = MTLStorageModeShared;
                       desc.usage = MTLTextureUsageShaderRead |
                                    MTLTextureUsageShaderWrite |
                                    MTLTextureUsageRenderTarget;

--- a/src/addon/metal/MetalClient.mm
+++ b/src/addon/metal/MetalClient.mm
@@ -115,6 +115,7 @@ MetalClientWrapper::MetalClientWrapper(const Napi::CallbackInfo& info)
 
         m_texture_listener->Call(reinterpret_cast<uint8_t*>(newSurf), width, height);
 
+        // We should pass a 'release' function to javascript to call this.
         [dstTex release];
         
         printf("Texture\n");

--- a/src/addon/metal/MetalClient.mm
+++ b/src/addon/metal/MetalClient.mm
@@ -230,15 +230,11 @@ void MetalClientWrapper::On(const Napi::CallbackInfo &info) {
 
     m_frame_listener->Set(env, callback);
   } else if (channel == "texture") {
-    printf("Try...\n");
     if (m_texture_listener == NULL) {
-      printf("Create...\n");
       // Create 'texture' listener.
       m_texture_listener = new TextureEventListener();
-      printf("Created...\n");
     }
     // Will replace listener if any was already set.
-    printf("Set...\n");
     m_texture_listener->Set(env, callback);
   } else {
     std::string err =

--- a/src/addon/metal/MetalClient.mm
+++ b/src/addon/metal/MetalClient.mm
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include <iostream>
+#include <stdio.h>
 #include <unistd.h>
 
 #include "MetalClient.h"
@@ -10,26 +10,26 @@ using namespace syphon;
 
 Napi::FunctionReference MetalClientWrapper::constructor;
 
-MetalClientWrapper::MetalClientWrapper(const Napi::CallbackInfo& info)
-: Napi::ObjectWrap<MetalClientWrapper>(info)
-{
+MetalClientWrapper::MetalClientWrapper(const Napi::CallbackInfo &info)
+    : Napi::ObjectWrap<MetalClientWrapper>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env); 
+  Napi::HandleScope scope(env);
 
-  if (info.Length() != 1 || !info[0].IsObject())
-  {
-    const char * err = "Please provide a valid server description.";
+  if (info.Length() != 1 || !info[0].IsObject()) {
+    const char *err = "Please provide a valid server description.";
     Napi::TypeError::New(env, err).ThrowAsJavaScriptException();
   }
 
   Napi::Object description = info[0].As<Napi::Object>();
+
   if (!IS_SERVER_DESCRIPTION(description)) {
-    const char * err = "Invalid server description.";
+    const char *err = "Invalid server description.";
     Napi::TypeError::New(env, err).ThrowAsJavaScriptException();
   }
-  NSDictionary * serverDescription = ServerDescriptionHelper::FromNapiObject(description);
+  NSDictionary *serverDescription =
+      ServerDescriptionHelper::FromNapiObject(description);
 
-  m_device =  MTLCreateSystemDefaultDevice();
+  m_device = MTLCreateSystemDefaultDevice();
   m_queue = [m_device newCommandQueue];
 
   m_client = NULL;
@@ -37,105 +37,117 @@ MetalClientWrapper::MetalClientWrapper(const Napi::CallbackInfo& info)
   m_frame_listener = NULL;
   m_texture_listener = NULL;
 
-  m_client = [[SyphonMetalClient alloc] initWithServerDescription: serverDescription
-                                                           device: m_device
-                                                          options: nil 
-                                                  newFrameHandler: ^(SyphonMetalClient *client) {
-    if (client) {
-      id<MTLTexture> frame = client.newFrameImage;
-      NSUInteger width = frame.width;
-      NSUInteger height = frame.height;
-      
-      
-      if (m_frame_listener != NULL) {
+  m_client = [[SyphonMetalClient alloc]
+      initWithServerDescription:serverDescription
+                         device:m_device
+                        options:nil
+                newFrameHandler:^(SyphonMetalClient *client) {
+                  if (client) {
+                    id<MTLTexture> frame = client.newFrameImage;
+                    NSUInteger width = frame.width;
+                    NSUInteger height = frame.height;
 
-        MTLRegion region = MTLRegionMake2D(0, 0, width, height);
+                    if (m_frame_listener != NULL) {
 
-        uint8_t * pixel_buffer = new uint8_t[width * height * 4];
-        std::memset(pixel_buffer, 0, width * height * 4);
+                      MTLRegion region = MTLRegionMake2D(0, 0, width, height);
 
-        [frame getBytes: pixel_buffer
-            bytesPerRow: 4 * width
-            fromRegion: region
-            mipmapLevel: 0];
+                      uint8_t *pixel_buffer = new uint8_t[width * height * 4];
+                      std::memset(pixel_buffer, 0, width * height * 4);
 
-        // Convert from BGRA to RGBA: could have an option to do it or not.
-        vImage_Buffer buffer = { .height = height, .width = width, .rowBytes = width * 4, .data = pixel_buffer };
-        const uint8_t map[] = { 2, 1, 0, 3 };
-        vImagePermuteChannels_ARGB8888(&buffer, &buffer, map, kvImageNoFlags);
+                      [frame getBytes:pixel_buffer
+                          bytesPerRow:4 * width
+                           fromRegion:region
+                          mipmapLevel:0];
 
-        m_frame_listener->Call((uint8_t *)buffer.data, width, height);
-      }
+                      // Convert from BGRA to RGBA: could have an option to do
+                      // it or not.
+                      vImage_Buffer buffer = {.height = height,
+                                              .width = width,
+                                              .rowBytes = width * 4,
+                                              .data = pixel_buffer};
+                      const uint8_t map[] = {2, 1, 0, 3};
+                      vImagePermuteChannels_ARGB8888(&buffer, &buffer, map,
+                                                     kvImageNoFlags);
 
-      if (m_texture_listener != NULL) {
-        printf("Width: %lu, Height: %lu\n", width, height);
-        static const OSType kBGRA = 'BGRA';
-        NSDictionary *surfaceProps = @{
-          (__bridge NSString*)kIOSurfaceWidth           : @(width),
-          (__bridge NSString*)kIOSurfaceHeight          : @(height),
-          (__bridge NSString*)kIOSurfacePixelFormat     : @(kBGRA),
-          (__bridge NSString*)kIOSurfaceBytesPerElement : @4,
-          (__bridge NSString*)kIOSurfaceBytesPerRow     : @(width * 4),
-          (__bridge NSString*)kIOSurfaceIsGlobal        : @YES
-        };
-        IOSurfaceRef newSurf = IOSurfaceCreate(
-            (__bridge CFDictionaryRef)surfaceProps);
+                      m_frame_listener->Call((uint8_t *)buffer.data, width,
+                                             height);
+                    }
 
-        // Wrap the surface in a Metal texture 
-        MTLTextureDescriptor *desc =
-          [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm
-                                                            width:width
-                                                            height:height
-                                                        mipmapped:NO];
-        desc.usage = MTLTextureUsageShaderRead |
-                    MTLTextureUsageShaderWrite |
-                    MTLTextureUsageRenderTarget;
-        id<MTLTexture> dstTex =
-          [m_device newTextureWithDescriptor:desc
-                                            iosurface:newSurf
-                                                plane:0];
+                    if (m_texture_listener != NULL) {
+                      printf("Width: %lu, Height: %lu\n", width, height);
+                      static const OSType kBGRA = 'BGRA';
+                      NSDictionary *surfaceProps = @{
+                        (__bridge NSString *)kIOSurfaceWidth : @(width),
+                        (__bridge NSString *)kIOSurfaceHeight : @(height),
+                        (__bridge NSString *)kIOSurfacePixelFormat : @(kBGRA),
+                        (__bridge NSString *)kIOSurfaceBytesPerElement : @4,
+                        (__bridge NSString *)
+                        kIOSurfaceBytesPerRow : @(width * 4),
+                        (__bridge NSString *)kIOSurfaceIsGlobal : @YES
+                      };
+                      IOSurfaceRef newSurf = IOSurfaceCreate(
+                          (__bridge CFDictionaryRef)surfaceProps);
 
-        // blit copy
-        id<MTLCommandBuffer> cmd = [m_queue commandBuffer];
-        id<MTLBlitCommandEncoder> blit = [cmd blitCommandEncoder];
-        MTLOrigin origin = {0,0,0};
-        MTLSize   size   = {width,height,1};
-        [blit copyFromTexture:frame
-                  sourceSlice:0
-                  sourceLevel:0
-                sourceOrigin:origin
-                  sourceSize:size
-                    toTexture:dstTex
-            destinationSlice:0
-            destinationLevel:0
-            destinationOrigin:origin];
-        [blit endEncoding];
-        [cmd commit];
-        [cmd waitUntilCompleted];
+                      // Wrap the surface in a Metal texture
+                      MTLTextureDescriptor *desc = [MTLTextureDescriptor
+                          texture2DDescriptorWithPixelFormat:
+                              MTLPixelFormatBGRA8Unorm
+                                                       width:width
+                                                      height:height
+                                                   mipmapped:NO];
+                      desc.usage = MTLTextureUsageShaderRead |
+                                   MTLTextureUsageShaderWrite |
+                                   MTLTextureUsageRenderTarget;
+                      id<MTLTexture> dstTex =
+                          [m_device newTextureWithDescriptor:desc
+                                                   iosurface:newSurf
+                                                       plane:0];
 
-        m_texture_listener->Call(reinterpret_cast<uint8_t*>(newSurf), width, height);
+                      // blit copy
+                      id<MTLCommandBuffer> cmd = [m_queue commandBuffer];
+                      id<MTLBlitCommandEncoder> blit = [cmd blitCommandEncoder];
+                      MTLOrigin origin = {0, 0, 0};
+                      MTLSize size = {width, height, 1};
+                      [blit copyFromTexture:frame
+                                sourceSlice:0
+                                sourceLevel:0
+                               sourceOrigin:origin
+                                 sourceSize:size
+                                  toTexture:dstTex
+                           destinationSlice:0
+                           destinationLevel:0
+                          destinationOrigin:origin];
+                      [blit endEncoding];
+                      [cmd commit];
+                      [cmd waitUntilCompleted];
 
-        // TODO: we should pass a 'release' function to javascript to call this.
-        // Comment this line to have a huge memory leak without crash. :)
-        [dstTex release];
-        
-        printf("Texture\n");
+                      m_texture_listener->Call(
+                          reinterpret_cast<uint8_t *>(newSurf), width, height);
 
-      }
+                      NSLog(@"Id: %p %lu", dstTex,
+                            MetalClientWrapper::GetUniqueId());
 
-      [frame release];
-    }   
-  }];
+                      // TODO: we should pass a 'release' function to javascript
+                      // to call this. Comment this line to have a huge memory
+                      // leak without crash. :)
+                      [dstTex release];
+
+                      printf("Texture\n");
+                    }
+
+                    [frame release];
+                  }
+                }];
 
   [serverDescription release];
 
   if (![m_client isValid]) {
-    Napi::Error::New(env, "SyphonMetalClient is not valid.").ThrowAsJavaScriptException();
+    Napi::Error::New(env, "SyphonMetalClient is not valid.")
+        .ThrowAsJavaScriptException();
   }
 }
 
-MetalClientWrapper::~MetalClientWrapper()
-{
+MetalClientWrapper::~MetalClientWrapper() {
   // Object is automatically destroyed.
 
   if (m_frame_listener != NULL) {
@@ -155,8 +167,7 @@ MetalClientWrapper::~MetalClientWrapper()
   }
 }
 
-void MetalClientWrapper::Dispose(const Napi::CallbackInfo& info)
-{
+void MetalClientWrapper::Dispose(const Napi::CallbackInfo &info) {
   // User explicitly called 'dispose'.
 
   if (m_frame_listener != NULL) {
@@ -176,21 +187,23 @@ void MetalClientWrapper::Dispose(const Napi::CallbackInfo& info)
   }
 }
 
-void MetalClientWrapper::On(const Napi::CallbackInfo &info)
-{
+void MetalClientWrapper::On(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
   Napi::HandleScope scope(env);
 
   if (info.Length() != 2) {
-      Napi::TypeError::New(env, "Listener registration takes 2 arguments.").ThrowAsJavaScriptException();
-    }
-    
+    Napi::TypeError::New(env, "Listener registration takes 2 arguments.")
+        .ThrowAsJavaScriptException();
+  }
+
   if (!(info[0].IsString())) {
-    Napi::TypeError::New(env, "1st parameter of 'on' must be a string.").ThrowAsJavaScriptException();
+    Napi::TypeError::New(env, "1st parameter of 'on' must be a string.")
+        .ThrowAsJavaScriptException();
   }
 
   if (!(info[1].IsFunction())) {
-    Napi::TypeError::New(env, "2nd parameter of 'on' must be a function.").ThrowAsJavaScriptException();
+    Napi::TypeError::New(env, "2nd parameter of 'on' must be a function.")
+        .ThrowAsJavaScriptException();
   }
 
   std::string channel = info[0].As<Napi::String>().Utf8Value();
@@ -202,9 +215,9 @@ void MetalClientWrapper::On(const Napi::CallbackInfo &info)
       m_frame_listener = new FrameEventListener();
     }
     // Will replace listener if any was already set.
-    
+
     m_frame_listener->Set(env, callback);
-  } else  if (channel == "texture") {
+  } else if (channel == "texture") {
     printf("Try...\n");
     if (m_texture_listener == NULL) {
       printf("Create...\n");
@@ -216,22 +229,24 @@ void MetalClientWrapper::On(const Napi::CallbackInfo &info)
     printf("Set...\n");
     m_texture_listener->Set(env, callback);
   } else {
-    std::string err = "String '" + channel + "' is not a valid channel listener.";
+    std::string err =
+        "String '" + channel + "' is not a valid channel listener.";
     Napi::TypeError::New(env, err).ThrowAsJavaScriptException();
   }
 }
 
-void MetalClientWrapper::Off(const Napi::CallbackInfo &info)
-{
+void MetalClientWrapper::Off(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
   Napi::HandleScope scope(env);
 
   if (info.Length() != 1) {
-      Napi::TypeError::New(env, "Listener removal takes 1 arguments (channel).").ThrowAsJavaScriptException();
-    }
-    
+    Napi::TypeError::New(env, "Listener removal takes 1 arguments (channel).")
+        .ThrowAsJavaScriptException();
+  }
+
   if (!(info[0].IsString())) {
-    Napi::TypeError::New(env, "1st parameter of 'off' must be a string.").ThrowAsJavaScriptException();
+    Napi::TypeError::New(env, "1st parameter of 'off' must be a string.")
+        .ThrowAsJavaScriptException();
   }
 
   std::string channel = info[0].As<Napi::String>().Utf8Value();
@@ -243,27 +258,28 @@ void MetalClientWrapper::Off(const Napi::CallbackInfo &info)
     // m_frame_listener = nullptr;
     m_texture_listener->Dispose();
   } else {
-    std::string err = "String '" + channel + "' is not a valid channel listener.";
+    std::string err =
+        "String '" + channel + "' is not a valid channel listener.";
     Napi::TypeError::New(env, err).ThrowAsJavaScriptException();
   }
 }
 
 #pragma mark NAPI methods.
 
-bool MetalClientWrapper::HasInstance(Napi::Value value)
-{
+bool MetalClientWrapper::HasInstance(Napi::Value value) {
   return value.As<Napi::Object>().InstanceOf(constructor.Value());
 }
 
-Napi::Object MetalClientWrapper::Init(Napi::Env env, Napi::Object exports)
-{
-	Napi::HandleScope scope(env);
+Napi::Object MetalClientWrapper::Init(Napi::Env env, Napi::Object exports) {
+  Napi::HandleScope scope(env);
 
-  Napi::Function func = DefineClass(env, "OpenGLClient", {
-    InstanceMethod("dispose", &MetalClientWrapper::Dispose),
-    InstanceMethod("on", &MetalClientWrapper::On),
-    InstanceMethod("off", &MetalClientWrapper::Off),
-  });
+  Napi::Function func =
+      DefineClass(env, "OpenGLClient",
+                  {
+                      InstanceMethod("dispose", &MetalClientWrapper::Dispose),
+                      InstanceMethod("on", &MetalClientWrapper::On),
+                      InstanceMethod("off", &MetalClientWrapper::Off),
+                  });
 
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
@@ -271,5 +287,4 @@ Napi::Object MetalClientWrapper::Init(Napi::Env env, Napi::Object exports)
   exports.Set("MetalClient", func);
 
   return exports;
-
 }

--- a/src/addon/metal/MetalClient.mm
+++ b/src/addon/metal/MetalClient.mm
@@ -115,7 +115,8 @@ MetalClientWrapper::MetalClientWrapper(const Napi::CallbackInfo& info)
 
         m_texture_listener->Call(reinterpret_cast<uint8_t*>(newSurf), width, height);
 
-        // We should pass a 'release' function to javascript to call this.
+        // TODO: we should pass a 'release' function to javascript to call this.
+        // Comment this line to have a huge memory leak without crash. :)
         [dstTex release];
         
         printf("Texture\n");

--- a/src/addon/metal/MetalClient.mm
+++ b/src/addon/metal/MetalClient.mm
@@ -13,36 +13,10 @@ using namespace syphon;
 
 Napi::FunctionReference MetalClientWrapper::constructor;
 
-static void sigHandler(int sig) {
-  const char* sigName;
-  switch (sig) {
-    case SIGINT: sigName = "SIGINT"; break;
-    case SIGSEGV: sigName = "SIGSEGV"; break;
-    case SIGBUS: sigName = "SIGBUS"; break;
-    case SIGTERM: sigName = "SIGTERM"; break;
-    default: sigName = "UNKNOWN"; break;
-  }
-  printf("{\"NodeSyphonMessageType\": \"NodeSyphonMessageError\", \"NodeSyphonMessage\": \"Signal handler called: %s (%d)\"}\n", sigName, sig);
-  void *callstack[64];
-  int frames = backtrace(callstack, 64);
-  char **strs = backtrace_symbols(callstack, frames);
-  fprintf(stderr, "Stack backtrace (most recent call first):\n");
-  for (int i = 0; i < frames; ++i) {
-    fprintf(stderr, "%s\n", strs[i]);
-  }
-  free(strs);
-  exit(1);
-}
-
 MetalClientWrapper::MetalClientWrapper(const Napi::CallbackInfo &info)
     : Napi::ObjectWrap<MetalClientWrapper>(info) {
   Napi::Env env = info.Env();
   Napi::HandleScope scope(env);
-
-  signal(SIGINT, sigHandler);
-  signal(SIGSEGV, sigHandler);
-  signal(SIGBUS, sigHandler);
-  signal(SIGTERM, sigHandler);
 
   if (info.Length() != 1 || !info[0].IsObject()) {
     const char *err = "Please provide a valid server description.";

--- a/src/addon/metal/MetalServer.h
+++ b/src/addon/metal/MetalServer.h
@@ -1,49 +1,48 @@
 #ifndef ___METAL_SERVER_H___
 #define ___METAL_SERVER_H___
 
-#include <napi.h>
 #include <map>
+#include <napi.h>
 
-#include <Foundation/Foundation.h>
 #include <Cocoa/Cocoa.h>
+#include <Foundation/Foundation.h>
 #include <Metal/Metal.h>
 #include <Syphon/Syphon.h>
 
 #include "../helpers/macros.h"
 
-namespace syphon
-{
+namespace syphon {
 
-  class MetalServerWrapper : public Napi::ObjectWrap<MetalServerWrapper>
-  {
+class MetalServerWrapper : public Napi::ObjectWrap<MetalServerWrapper> {
 
-  public:
-    static Napi::Object Init(Napi::Env env, Napi::Object exports);
+public:
+  static Napi::Object Init(Napi::Env env, Napi::Object exports);
 
-    MetalServerWrapper(const Napi::CallbackInfo &info);
-    ~MetalServerWrapper();
+  MetalServerWrapper(const Napi::CallbackInfo &info);
+  ~MetalServerWrapper();
 
-    static bool HasInstance(Napi::Value value);
+  static bool HasInstance(Napi::Value value);
 
-    void Dispose(const Napi::CallbackInfo &info);
+  void Dispose(const Napi::CallbackInfo &info);
 
-    void PublishImageData(const Napi::CallbackInfo &info);
-    void PublishSurfaceHandle(const Napi::CallbackInfo &info);
-    // void PublishFrameTexture(const Napi::CallbackInfo &info);
+  void PublishImageData(const Napi::CallbackInfo &info);
+  void PublishSurfaceHandle(const Napi::CallbackInfo &info);
+  // void PublishFrameTexture(const Napi::CallbackInfo &info);
 
-    Napi::Value GetName(const Napi::CallbackInfo &info);
-    Napi::Value GetServerDescription(const Napi::CallbackInfo &info);
-    Napi::Value HasClients(const Napi::CallbackInfo &info);
+  Napi::Value GetName(const Napi::CallbackInfo &info);
+  Napi::Value GetServerDescription(const Napi::CallbackInfo &info);
+  Napi::Value HasClients(const Napi::CallbackInfo &info);
 
-    SyphonMetalServer * m_server;
-  private:
-    static Napi::FunctionReference constructor;
+  SyphonMetalServer *m_server;
 
-    bool m_first_check_passed;
-    id<MTLDevice> m_device;
-    id<MTLCommandQueue> m_queue;
-    id<MTLTexture> m_texture;
-  };
-}
+private:
+  static Napi::FunctionReference constructor;
+
+  bool m_first_check_passed;
+  id<MTLDevice> m_device;
+  id<MTLCommandQueue> m_queue;
+  id<MTLTexture> m_texture;
+};
+} // namespace syphon
 
 #endif

--- a/src/addon/metal/MetalServer.mm
+++ b/src/addon/metal/MetalServer.mm
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include <iostream>
+#include <stdio.h>
 
 #include "MetalServer.h"
 
@@ -9,15 +9,13 @@ using namespace syphon;
 
 Napi::FunctionReference MetalServerWrapper::constructor;
 
-MetalServerWrapper::MetalServerWrapper(const Napi::CallbackInfo& info)
-: Napi::ObjectWrap<MetalServerWrapper>(info)
-{
+MetalServerWrapper::MetalServerWrapper(const Napi::CallbackInfo &info)
+    : Napi::ObjectWrap<MetalServerWrapper>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env); 
+  Napi::HandleScope scope(env);
 
-  if (info.Length() != 1 || !info[0].IsString())
-  {
-    const char * err = "Please provide an unique name for the server.";
+  if (info.Length() != 1 || !info[0].IsString()) {
+    const char *err = "Please provide an unique name for the server.";
     Napi::TypeError::New(env, err).ThrowAsJavaScriptException();
   }
 
@@ -26,224 +24,251 @@ MetalServerWrapper::MetalServerWrapper(const Napi::CallbackInfo& info)
   m_device = MTLCreateSystemDefaultDevice();
   m_queue = [m_device newCommandQueue];
 
-  m_server = [[SyphonMetalServer alloc] initWithName:TO_NSSTRING(info[0]) device:m_device options:nil];
+  m_server = [[SyphonMetalServer alloc] initWithName:TO_NSSTRING(info[0])
+                                              device:m_device
+                                             options:nil];
 }
 
-MetalServerWrapper::~MetalServerWrapper()
-{
+MetalServerWrapper::~MetalServerWrapper() {
   if (m_server != NULL) {
     [m_server release];
     m_server = NULL;
   }
 }
 
-void MetalServerWrapper::Dispose(const Napi::CallbackInfo& info)
-{
+void MetalServerWrapper::Dispose(const Napi::CallbackInfo &info) {
   if (m_server != NULL) {
     [m_server release];
     m_server = NULL;
   }
 }
 
-void MetalServerWrapper::PublishImageData(const Napi::CallbackInfo& info)
-{
+void MetalServerWrapper::PublishImageData(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
   Napi::HandleScope scope(env);
 
-  // Only test the parameters on first call: we suppose that the function will be called 
-  // with same parameters, so we can avoid checking at each new frame.
-  
+  // Only test the parameters on first call: we suppose that the function will
+  // be called with same parameters, so we can avoid checking at each new frame.
+
   if (!m_first_check_passed) {
 
     if (info.Length() != 4) {
-      Napi::TypeError::New(env, "publishImageData expects (Uint8ClampedArray, rect, size, bool)").ThrowAsJavaScriptException();
+      Napi::TypeError::New(
+          env, "publishImageData expects (Uint8ClampedArray, rect, size, bool)")
+          .ThrowAsJavaScriptException();
     }
-    
+
     if (!IS_UINT8_CLAMPED_ARRAY(info[0])) {
-      Napi::TypeError::New(env, "1st parameter (data) must be an Uint8ClampedArray in 'publishImageData'").ThrowAsJavaScriptException();
+      Napi::TypeError::New(env, "1st parameter (data) must be an "
+                                "Uint8ClampedArray in 'publishImageData'")
+          .ThrowAsJavaScriptException();
     }
 
     if (!IS_RECT(info[1])) {
-      Napi::TypeError::New(env, "2nd parameter (imageRegion) must be a rectangle in 'publishImageData'").ThrowAsJavaScriptException();
+      Napi::TypeError::New(env, "2nd parameter (imageRegion) must be a "
+                                "rectangle in 'publishImageData'")
+          .ThrowAsJavaScriptException();
     }
 
     if (!IS_SIZE(info[2])) {
-      Napi::TypeError::New(env, "3rd parameter (textureDimensions) must be a size in 'publishImageData'").ThrowAsJavaScriptException();
+      Napi::TypeError::New(env, "3rd parameter (textureDimensions) must be a "
+                                "size in 'publishImageData'")
+          .ThrowAsJavaScriptException();
     }
 
     if (!info[3].IsBoolean()) {
-      Napi::TypeError::New(env, "4th parameter (flipped) must be a boolean in 'publishImageData'").ThrowAsJavaScriptException();
+      Napi::TypeError::New(
+          env,
+          "4th parameter (flipped) must be a boolean in 'publishImageData'")
+          .ThrowAsJavaScriptException();
     }
 
     m_first_check_passed = true;
   }
 
-    Napi::Object region = info[1].As<Napi::Object>();
-    NSRect imageRegion = NSMakeRect(region.Get("x").ToNumber().Uint32Value(), region.Get("y").ToNumber().Uint32Value(), region.Get("width").ToNumber().Uint32Value(), region.Get("height").ToNumber().Uint32Value());
-    
-    Napi::Object size = info[2].As<Napi::Object>();
-    NSSize texture_size = NSMakeSize(size.Get("width").ToNumber().FloatValue(), size.Get("height").ToNumber().FloatValue());
-    NSUInteger bytesPerRow = NSUInteger(texture_size.width) * 4;
-    
-    BOOL flipped = info[3].As<Napi::Boolean>().Value() == true ? YES : NO; 
+  Napi::Object region = info[1].As<Napi::Object>();
+  NSRect imageRegion =
+      NSMakeRect(region.Get("x").ToNumber().Uint32Value(),
+                 region.Get("y").ToNumber().Uint32Value(),
+                 region.Get("width").ToNumber().Uint32Value(),
+                 region.Get("height").ToNumber().Uint32Value());
 
-    Napi::ArrayBuffer buffer = info[0].As<Napi::TypedArrayOf<uint8_t>>().ArrayBuffer(); 
+  Napi::Object size = info[2].As<Napi::Object>();
+  NSSize texture_size = NSMakeSize(size.Get("width").ToNumber().FloatValue(),
+                                   size.Get("height").ToNumber().FloatValue());
+  NSUInteger bytesPerRow = NSUInteger(texture_size.width) * 4;
 
-    MTLTextureDescriptor *descriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat: MTLPixelFormatRGBA8Unorm
-                                                             width: (NSUInteger) texture_size.width 
-                                                             height: (NSUInteger) texture_size.height
-                                                             mipmapped: NO];
+  BOOL flipped = info[3].As<Napi::Boolean>().Value() == true ? YES : NO;
 
-    m_texture = [m_device newTextureWithDescriptor: descriptor];
-    [m_texture replaceRegion: MTLRegionMake2D(imageRegion.origin.x, imageRegion.origin.y, imageRegion.size.width, imageRegion.size.height)
-              mipmapLevel: 0
-              withBytes: buffer.Data()
-              bytesPerRow: bytesPerRow];
+  Napi::ArrayBuffer buffer =
+      info[0].As<Napi::TypedArrayOf<uint8_t>>().ArrayBuffer();
 
-    id<MTLCommandBuffer> cmd = [m_queue commandBuffer]; 
-    
-    [m_server publishFrameTexture: m_texture
-              onCommandBuffer: cmd
-              imageRegion: imageRegion
-              flipped: flipped];
+  MTLTextureDescriptor *descriptor = [MTLTextureDescriptor
+      texture2DDescriptorWithPixelFormat:MTLPixelFormatRGBA8Unorm
+                                   width:(NSUInteger)texture_size.width
+                                  height:(NSUInteger)texture_size.height
+                               mipmapped:NO];
 
-    // @RenaudRohlinger Should we add this?
-    /*
-    [cmd addCompletedHandler:^(__unused id<MTLCommandBuffer> cb) {
-        [m_texture release];          // keep lifetime until GPU is done
-    }];
-    */
-    [cmd commit];
+  m_texture = [m_device newTextureWithDescriptor:descriptor];
+  [m_texture replaceRegion:MTLRegionMake2D(
+                               imageRegion.origin.x, imageRegion.origin.y,
+                               imageRegion.size.width, imageRegion.size.height)
+               mipmapLevel:0
+                 withBytes:buffer.Data()
+               bytesPerRow:bytesPerRow];
+
+  id<MTLCommandBuffer> cmd = [m_queue commandBuffer];
+
+  [m_server publishFrameTexture:m_texture
+                onCommandBuffer:cmd
+                    imageRegion:imageRegion
+                        flipped:flipped];
+
+  // @RenaudRohlinger Should we add this?
+  /*
+  [cmd addCompletedHandler:^(__unused id<MTLCommandBuffer> cb) {
+      [m_texture release];          // keep lifetime until GPU is done
+  }];
+  */
+  [cmd commit];
 }
 
-void MetalServerWrapper::PublishSurfaceHandle(const Napi::CallbackInfo& info)
-{
-    Napi::Env env = info.Env();
-    Napi::HandleScope scope(env);
+void MetalServerWrapper::PublishSurfaceHandle(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
 
-    /* ──────────────────────────── Parameter checks (first call only) */
-    if (!m_first_check_passed)
-    {
-        if (info.Length() != 4)
-            Napi::TypeError::New(env,
-              "'publishSurfaceHandle' expects (Buffer, rect, size, bool)")
-              .ThrowAsJavaScriptException();
+  /* ──────────────────────────── Parameter checks (first call only) */
+  if (!m_first_check_passed) {
+    if (info.Length() != 4)
+      Napi::TypeError::New(
+          env, "'publishSurfaceHandle' expects (Buffer, rect, size, bool)")
+          .ThrowAsJavaScriptException();
 
-        if (!IS_BUFFER(info[0]))
-            Napi::TypeError::New(env,
-              "1st parameter (handle) must be a Buffer in 'publishSurfaceHandle'")
-              .ThrowAsJavaScriptException();
+    if (!IS_BUFFER(info[0]))
+      Napi::TypeError::New(
+          env,
+          "1st parameter (handle) must be a Buffer in 'publishSurfaceHandle'")
+          .ThrowAsJavaScriptException();
 
-        if (!IS_RECT(info[1]))
-            Napi::TypeError::New(env,
-              "2nd parameter (imageRegion) must be a rectangle in 'publishSurfaceHandle'").ThrowAsJavaScriptException();
+    if (!IS_RECT(info[1]))
+      Napi::TypeError::New(env, "2nd parameter (imageRegion) must be a "
+                                "rectangle in 'publishSurfaceHandle'")
+          .ThrowAsJavaScriptException();
 
-        if (!IS_SIZE(info[2]))
-            Napi::TypeError::New(env,
-              "3rd parameter (textureDimensions) must be a size in 'publishSurfaceHandle'").ThrowAsJavaScriptException();
+    if (!IS_SIZE(info[2]))
+      Napi::TypeError::New(env, "3rd parameter (textureDimensions) must be a "
+                                "size in 'publishSurfaceHandle'")
+          .ThrowAsJavaScriptException();
 
-        if (!info[3].IsBoolean())
-            Napi::TypeError::New(env,
-              "4th parameter (flipped) must be a boolean in 'publishSurfaceHandle'").ThrowAsJavaScriptException();
+    if (!info[3].IsBoolean())
+      Napi::TypeError::New(
+          env,
+          "4th parameter (flipped) must be a boolean in 'publishSurfaceHandle'")
+          .ThrowAsJavaScriptException();
 
-        m_first_check_passed = true;
-    }
+    m_first_check_passed = true;
+  }
 
-    auto raw      = info[0].As<Napi::Buffer<void **>>();
-    IOSurfaceRef ioSurface = *reinterpret_cast<IOSurfaceRef *>(raw.Data());
+  auto raw = info[0].As<Napi::Buffer<void **>>();
+  IOSurfaceRef ioSurface = *reinterpret_cast<IOSurfaceRef *>(raw.Data());
 
-    Napi::Object regionObj = info[1].As<Napi::Object>();
-    NSRect imageRegion = NSMakeRect(regionObj.Get("x"    ).ToNumber().DoubleValue(),
-                                    regionObj.Get("y"    ).ToNumber().DoubleValue(),
-                                    regionObj.Get("width").ToNumber().DoubleValue(),
-                                    regionObj.Get("height").ToNumber().DoubleValue());
+  Napi::Object regionObj = info[1].As<Napi::Object>();
+  NSRect imageRegion =
+      NSMakeRect(regionObj.Get("x").ToNumber().DoubleValue(),
+                 regionObj.Get("y").ToNumber().DoubleValue(),
+                 regionObj.Get("width").ToNumber().DoubleValue(),
+                 regionObj.Get("height").ToNumber().DoubleValue());
 
-    Napi::Object sizeObj = info[2].As<Napi::Object>();
-    NSSize textureDims = NSMakeSize(sizeObj.Get("width" ).ToNumber().DoubleValue(),
-                                    sizeObj.Get("height").ToNumber().DoubleValue());
+  Napi::Object sizeObj = info[2].As<Napi::Object>();
+  NSSize textureDims =
+      NSMakeSize(sizeObj.Get("width").ToNumber().DoubleValue(),
+                 sizeObj.Get("height").ToNumber().DoubleValue());
 
-    BOOL flipped = info[3].As<Napi::Boolean>().Value() ? YES : NO;
+  BOOL flipped = info[3].As<Napi::Boolean>().Value() ? YES : NO;
 
-    /* ──────────────────────────── Create an IOSurface-backed MTLTexture */
-    const size_t width  = IOSurfaceGetWidth (ioSurface);
-    const size_t height = IOSurfaceGetHeight(ioSurface);
+  /* ──────────────────────────── Create an IOSurface-backed MTLTexture */
+  const size_t width = IOSurfaceGetWidth(ioSurface);
+  const size_t height = IOSurfaceGetHeight(ioSurface);
 
-    MTLTextureDescriptor *desc =
-        [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm
-                                                           width:width
-                                                          height:height
-                                                       mipmapped:NO];
-    desc.usage         = MTLTextureUsageShaderRead   |
-                         MTLTextureUsageShaderWrite  |
-                         MTLTextureUsageRenderTarget;
-    desc.storageMode   = MTLStorageModeShared;         // IOSurface is shareable
-    desc.resourceOptions = MTLResourceCPUCacheModeDefaultCache | MTLResourceStorageModeShared;
+  MTLTextureDescriptor *desc = [MTLTextureDescriptor
+      texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm
+                                   width:width
+                                  height:height
+                               mipmapped:NO];
+  desc.usage = MTLTextureUsageShaderRead | MTLTextureUsageShaderWrite |
+               MTLTextureUsageRenderTarget;
+  desc.storageMode = MTLStorageModeShared; // IOSurface is shareable
+  desc.resourceOptions =
+      MTLResourceCPUCacheModeDefaultCache | MTLResourceStorageModeShared;
 
-    id<MTLTexture> surfaceTexture =
-        [m_device newTextureWithDescriptor:desc
-                                  iosurface:ioSurface
-                                      plane:0];
-    if (!surfaceTexture)
-    {
-        Napi::Error::New(env, "Failed to create MTLTexture from IOSurface")
-            .ThrowAsJavaScriptException();
-        return;
-    }
+  id<MTLTexture> surfaceTexture = [m_device newTextureWithDescriptor:desc
+                                                           iosurface:ioSurface
+                                                               plane:0];
+  if (!surfaceTexture) {
+    Napi::Error::New(env, "Failed to create MTLTexture from IOSurface")
+        .ThrowAsJavaScriptException();
+    return;
+  }
 
-    /* ──────────────────────────── Publish to Syphon */
-    id<MTLCommandBuffer> cmd = [m_queue commandBuffer];
+  /* ──────────────────────────── Publish to Syphon */
+  id<MTLCommandBuffer> cmd = [m_queue commandBuffer];
 
-    [m_server publishFrameTexture:surfaceTexture
-                 onCommandBuffer:cmd
-                     imageRegion:imageRegion
-                         flipped:flipped];
+  [m_server publishFrameTexture:surfaceTexture
+                onCommandBuffer:cmd
+                    imageRegion:imageRegion
+                        flipped:flipped];
 
-    [cmd addCompletedHandler:^(__unused id<MTLCommandBuffer> cb) {
-        [surfaceTexture release];          // keep lifetime until GPU is done
-    }];
-    [cmd commit];
+  [cmd addCompletedHandler:^(__unused id<MTLCommandBuffer> cb) {
+    [surfaceTexture release]; // keep lifetime until GPU is done
+  }];
+  [cmd commit];
 }
 
-Napi::Value MetalServerWrapper::GetName(const Napi::CallbackInfo &info) 
-{
+Napi::Value MetalServerWrapper::GetName(const Napi::CallbackInfo &info) {
   return Napi::String::New(info.Env(), [[m_server name] UTF8String]);
 }
 
-Napi::Value MetalServerWrapper::GetServerDescription(const Napi::CallbackInfo &info) 
-{
-  return ServerDescriptionHelper::ToNapiObject([m_server serverDescription], info);
+Napi::Value
+MetalServerWrapper::GetServerDescription(const Napi::CallbackInfo &info) {
+  return ServerDescriptionHelper::ToNapiObject([m_server serverDescription],
+                                               info);
 }
 
-Napi::Value MetalServerWrapper::HasClients(const Napi::CallbackInfo &info) 
-{
+Napi::Value MetalServerWrapper::HasClients(const Napi::CallbackInfo &info) {
   return Napi::Boolean::New(info.Env(), [m_server hasClients]);
 }
 
-bool MetalServerWrapper::HasInstance(Napi::Value value)
-{
+bool MetalServerWrapper::HasInstance(Napi::Value value) {
   return value.As<Napi::Object>().InstanceOf(constructor.Value());
 }
 
-Napi::Object MetalServerWrapper::Init(Napi::Env env, Napi::Object exports)
-{
+Napi::Object MetalServerWrapper::Init(Napi::Env env, Napi::Object exports) {
 
-	Napi::HandleScope scope(env);
+  Napi::HandleScope scope(env);
 
-  Napi::Function func = DefineClass(env, "MetalServer", {
+  Napi::Function func = DefineClass(
+      env, "MetalServer",
+      {
 
-    // Methods.
+          // Methods.
 
-    InstanceMethod("publishImageData", &MetalServerWrapper::PublishImageData),
-    InstanceMethod("publishSurfaceHandle", &MetalServerWrapper::PublishSurfaceHandle),
-    InstanceMethod("dispose", &MetalServerWrapper::Dispose),
+          InstanceMethod("publishImageData",
+                         &MetalServerWrapper::PublishImageData),
+          InstanceMethod("publishSurfaceHandle",
+                         &MetalServerWrapper::PublishSurfaceHandle),
+          InstanceMethod("dispose", &MetalServerWrapper::Dispose),
 
-    // Accessors.
+          // Accessors.
 
-    InstanceAccessor("name", &MetalServerWrapper::GetName, nullptr, napi_enumerable),
-    InstanceAccessor("serverDescription", &MetalServerWrapper::GetServerDescription, nullptr, napi_enumerable),
-    InstanceAccessor("hasClients", &MetalServerWrapper::HasClients, nullptr, napi_enumerable),    
+          InstanceAccessor("name", &MetalServerWrapper::GetName, nullptr,
+                           napi_enumerable),
+          InstanceAccessor("serverDescription",
+                           &MetalServerWrapper::GetServerDescription, nullptr,
+                           napi_enumerable),
+          InstanceAccessor("hasClients", &MetalServerWrapper::HasClients,
+                           nullptr, napi_enumerable),
 
-  });
+      });
 
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
@@ -251,5 +276,4 @@ Napi::Object MetalServerWrapper::Init(Napi::Env env, Napi::Object exports)
   exports.Set("MetalServer", func);
 
   return exports;
-
 }

--- a/src/addon/opengl/OpenGLClient.h
+++ b/src/addon/opengl/OpenGLClient.h
@@ -1,37 +1,35 @@
 #ifndef ___OPENGL_CLIENT_H___
 #define ___OPENGL_CLIENT_H___
 
-#include <napi.h>
 #include <Foundation/Foundation.h>
+#include <napi.h>
 // #include <Cocoa/Cocoa.h>
-#include <Syphon/Syphon.h>
-#include <OpenGL/gl.h>
-#include "../helpers/macros.h"
 #include "../event-listeners/FrameEventListener.h"
+#include "../helpers/macros.h"
+#include <OpenGL/gl.h>
+#include <Syphon/Syphon.h>
 
-namespace syphon
-{
+namespace syphon {
 
-  class OpenGLClientWrapper : public Napi::ObjectWrap<OpenGLClientWrapper>
-  {
+class OpenGLClientWrapper : public Napi::ObjectWrap<OpenGLClientWrapper> {
 
-  public:
-    static Napi::Object Init(Napi::Env env, Napi::Object exports);
-    static bool HasInstance(Napi::Value value);
+public:
+  static Napi::Object Init(Napi::Env env, Napi::Object exports);
+  static bool HasInstance(Napi::Value value);
 
-    OpenGLClientWrapper(const Napi::CallbackInfo &info);
-    ~OpenGLClientWrapper();
+  OpenGLClientWrapper(const Napi::CallbackInfo &info);
+  ~OpenGLClientWrapper();
 
-    void Dispose(const Napi::CallbackInfo &info);
-    void On(const Napi::CallbackInfo &info);
-    void Off(const Napi::CallbackInfo &info);
+  void Dispose(const Napi::CallbackInfo &info);
+  void On(const Napi::CallbackInfo &info);
+  void Off(const Napi::CallbackInfo &info);
 
-  private:
-    static Napi::FunctionReference constructor;
+private:
+  static Napi::FunctionReference constructor;
 
-    SyphonOpenGLClient * m_client;
-    FrameEventListener * m_frame_listener;
-  };
-}
+  SyphonOpenGLClient *m_client;
+  FrameEventListener *m_frame_listener;
+};
+} // namespace syphon
 
 #endif

--- a/src/addon/opengl/OpenGLHelper.h
+++ b/src/addon/opengl/OpenGLHelper.h
@@ -1,20 +1,19 @@
 #ifndef ___OPENGL_HELPER_H___
 #define ___OPENGL_HELPER_H___
 
-#include <napi.h>
-#include <Foundation/Foundation.h>
 #include <Cocoa/Cocoa.h>
+#include <Foundation/Foundation.h>
 #include <OpenGL/gl.h>
+#include <napi.h>
 
-namespace syphon
-{
-  class OpenGLHelper : public Napi::ObjectWrap<OpenGLHelper>
-  {
-    public:
-        static CGLContextObj CreateContext(Napi::Env env);
-        static uint8_t * TextureToUint8(GLuint texture, size_t width, size_t height);
-        static void Uint8ToTexture(GLenum textureTarget, GLuint texture, size_t width, size_t height, uint8_t * data);
-  };
-}
+namespace syphon {
+class OpenGLHelper : public Napi::ObjectWrap<OpenGLHelper> {
+public:
+  static CGLContextObj CreateContext(Napi::Env env);
+  static uint8_t *TextureToUint8(GLuint texture, size_t width, size_t height);
+  static void Uint8ToTexture(GLenum textureTarget, GLuint texture, size_t width,
+                             size_t height, uint8_t *data);
+};
+} // namespace syphon
 
 #endif

--- a/src/addon/opengl/OpenGLHelper.mm
+++ b/src/addon/opengl/OpenGLHelper.mm
@@ -2,33 +2,33 @@
 
 using namespace syphon;
 
-// Thanks to https://stackoverflow.com/questions/61035830/how-to-create-an-opengl-context-on-an-nodejs-native-addon-on-macos
-CGLContextObj OpenGLHelper::CreateContext(Napi::Env env)
-{
+// Thanks to
+// https://stackoverflow.com/questions/61035830/how-to-create-an-opengl-context-on-an-nodejs-native-addon-on-macos
+CGLContextObj OpenGLHelper::CreateContext(Napi::Env env) {
   CGLContextObj context;
 
-  CGLPixelFormatAttribute attributes[3] = {
-    kCGLPFAAccelerated, 
-    kCGLPFANoRecovery,
-    // kCGLPFADoubleBuffer,
-    (CGLPixelFormatAttribute) 0
-  };
+  CGLPixelFormatAttribute attributes[3] = {kCGLPFAAccelerated,
+                                           kCGLPFANoRecovery,
+                                           // kCGLPFADoubleBuffer,
+                                           (CGLPixelFormatAttribute)0};
 
   CGLPixelFormatObj pix;
-  GLint num; 
+  GLint num;
 
   CGLError error_code;
   error_code = CGLChoosePixelFormat(attributes, &pix, &num);
 
   if (error_code > 0) {
     printf("Error 1\n");
-    Napi::Error::New(env, CGLErrorString(error_code)).ThrowAsJavaScriptException();
+    Napi::Error::New(env, CGLErrorString(error_code))
+        .ThrowAsJavaScriptException();
   }
 
   error_code = CGLCreateContext(pix, NULL, &context);
   if (error_code > 0) {
     printf("Error 2\n");
-    Napi::Error::New(env, CGLErrorString(error_code)).ThrowAsJavaScriptException();
+    Napi::Error::New(env, CGLErrorString(error_code))
+        .ThrowAsJavaScriptException();
   }
 
   CGLDestroyPixelFormat(pix);
@@ -36,9 +36,9 @@ CGLContextObj OpenGLHelper::CreateContext(Napi::Env env)
   return context;
 }
 
-uint8_t * OpenGLHelper::TextureToUint8(GLuint texture, size_t width, size_t height)
-{
-  uint8_t* pixel_buffer = new uint8_t[width * height * 4];
+uint8_t *OpenGLHelper::TextureToUint8(GLuint texture, size_t width,
+                                      size_t height) {
+  uint8_t *pixel_buffer = new uint8_t[width * height * 4];
   std::memset(pixel_buffer, 0, width * height * 4);
 
   GLuint fbo;
@@ -47,7 +47,8 @@ uint8_t * OpenGLHelper::TextureToUint8(GLuint texture, size_t width, size_t heig
 
   glGenFramebuffers(1, &fbo);
   glBindFramebuffer(GL_FRAMEBUFFER, fbo);
-  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_RECTANGLE_EXT, texture, 0);
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                         GL_TEXTURE_RECTANGLE_EXT, texture, 0);
 
   glEnable(GL_TEXTURE_RECTANGLE_EXT);
   glDisable(GL_DEPTH_TEST);
@@ -64,11 +65,13 @@ uint8_t * OpenGLHelper::TextureToUint8(GLuint texture, size_t width, size_t heig
   return pixel_buffer;
 }
 
-void OpenGLHelper::Uint8ToTexture(GLenum textureTarget, GLuint texture, size_t width, size_t height, uint8_t * data) {
+void OpenGLHelper::Uint8ToTexture(GLenum textureTarget, GLuint texture,
+                                  size_t width, size_t height, uint8_t *data) {
   glEnable(textureTarget);
   glBindTexture(textureTarget, texture);
 
-  glTexImage2D(textureTarget, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
+  glTexImage2D(textureTarget, 0, GL_RGBA, width, height, 0, GL_RGBA,
+               GL_UNSIGNED_BYTE, data);
 
   glTexParameteri(textureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
   glTexParameteri(textureTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);

--- a/src/addon/opengl/OpenGLServer.h
+++ b/src/addon/opengl/OpenGLServer.h
@@ -1,49 +1,48 @@
 #ifndef ___OPENGL_SERVER_H___
 #define ___OPENGL_SERVER_H___
 
-#include <napi.h>
 #include <map>
+#include <napi.h>
 
-#include <Foundation/Foundation.h>
 #include <Cocoa/Cocoa.h>
+#include <Foundation/Foundation.h>
+#include <IOSurface/IOSurface.h>
 #include <OpenGL/OpenGL.h>
 #include <Syphon/Syphon.h>
-#include <IOSurface/IOSurface.h>
 
 // Macros.
 
 #include "../helpers/macros.h"
 
-namespace syphon
-{
+namespace syphon {
 
-  class OpenGLServerWrapper : public Napi::ObjectWrap<OpenGLServerWrapper>
-  {
+class OpenGLServerWrapper : public Napi::ObjectWrap<OpenGLServerWrapper> {
 
-  public:
-    static Napi::Object Init(Napi::Env env, Napi::Object exports);
+public:
+  static Napi::Object Init(Napi::Env env, Napi::Object exports);
 
-    OpenGLServerWrapper(const Napi::CallbackInfo &info);
-    ~OpenGLServerWrapper();
+  OpenGLServerWrapper(const Napi::CallbackInfo &info);
+  ~OpenGLServerWrapper();
 
-    static bool HasInstance(Napi::Value value);
+  static bool HasInstance(Napi::Value value);
 
-    void Dispose(const Napi::CallbackInfo &info);
+  void Dispose(const Napi::CallbackInfo &info);
 
-    void PublishImageData(const Napi::CallbackInfo &info);
-    void PublishSurfacehandle(const Napi::CallbackInfo &info);
+  void PublishImageData(const Napi::CallbackInfo &info);
+  void PublishSurfacehandle(const Napi::CallbackInfo &info);
 
-    Napi::Value GetName(const Napi::CallbackInfo &info);
-    Napi::Value GetServerDescription(const Napi::CallbackInfo &info);
-    Napi::Value HasClients(const Napi::CallbackInfo &info);
+  Napi::Value GetName(const Napi::CallbackInfo &info);
+  Napi::Value GetServerDescription(const Napi::CallbackInfo &info);
+  Napi::Value HasClients(const Napi::CallbackInfo &info);
 
-    SyphonOpenGLServer *m_server;
-  private:
-    static Napi::FunctionReference constructor;
+  SyphonOpenGLServer *m_server;
 
-    bool m_first_check_passed;
-    GLuint m_texture;
-  };
-}
+private:
+  static Napi::FunctionReference constructor;
+
+  bool m_first_check_passed;
+  GLuint m_texture;
+};
+} // namespace syphon
 
 #endif

--- a/src/addon/opengl/OpenGLServer.mm
+++ b/src/addon/opengl/OpenGLServer.mm
@@ -1,25 +1,22 @@
-#include <stdio.h>
 #include <iostream>
+#include <stdio.h>
 
-#include "OpenGLServer.h"
 #include "OpenGLHelper.h"
+#include "OpenGLServer.h"
 
 #import "../helpers/ServerDescriptionHelper.h"
-
 
 using namespace syphon;
 
 Napi::FunctionReference OpenGLServerWrapper::constructor;
 
-OpenGLServerWrapper::OpenGLServerWrapper(const Napi::CallbackInfo& info)
-: Napi::ObjectWrap<OpenGLServerWrapper>(info)
-{
+OpenGLServerWrapper::OpenGLServerWrapper(const Napi::CallbackInfo &info)
+    : Napi::ObjectWrap<OpenGLServerWrapper>(info) {
   Napi::Env env = info.Env();
-  Napi::HandleScope scope(env); 
+  Napi::HandleScope scope(env);
 
-  if (info.Length() != 1 || !info[0].IsString())
-  {
-    const char * err = "Please provide an unique name for the server.";
+  if (info.Length() != 1 || !info[0].IsString()) {
+    const char *err = "Please provide an unique name for the server.";
     Napi::TypeError::New(env, err).ThrowAsJavaScriptException();
   }
 
@@ -28,150 +25,188 @@ OpenGLServerWrapper::OpenGLServerWrapper(const Napi::CallbackInfo& info)
 
   // Bootstrap a context for Syphon server.
   CGLContextObj cgl_ctx = OpenGLHelper::CreateContext(env);
-  m_server = [[SyphonOpenGLServer alloc] initWithName:TO_NSSTRING(info[0]) context:cgl_ctx options:nil];
+  m_server = [[SyphonOpenGLServer alloc] initWithName:TO_NSSTRING(info[0])
+                                              context:cgl_ctx
+                                              options:nil];
 }
 
-OpenGLServerWrapper::~OpenGLServerWrapper()
-{
+OpenGLServerWrapper::~OpenGLServerWrapper() {
   if (m_server != NULL) {
     [m_server release];
     m_server = NULL;
   }
 }
 
-void OpenGLServerWrapper::Dispose(const Napi::CallbackInfo& info)
-{
+void OpenGLServerWrapper::Dispose(const Napi::CallbackInfo &info) {
   if (m_server != NULL) {
     [m_server release];
     m_server = NULL;
   }
 }
 
-void OpenGLServerWrapper::PublishImageData(const Napi::CallbackInfo& info)
-{
+void OpenGLServerWrapper::PublishImageData(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
   Napi::HandleScope scope(env);
 
-  // Only test the parameters on first call: we suppose that the function will be called 
-  // with same parameters, so we can avoid checking at each new frame.
-  
+  // Only test the parameters on first call: we suppose that the function will
+  // be called with same parameters, so we can avoid checking at each new frame.
+
   if (!m_first_check_passed) {
     if (info.Length() != 5) {
-      Napi::TypeError::New(env, "Invalid number of parameters for 'publishImageData'").ThrowAsJavaScriptException();
+      Napi::TypeError::New(
+          env, "Invalid number of parameters for 'publishImageData'")
+          .ThrowAsJavaScriptException();
     }
-    
+
     if (!IS_UINT8_CLAMPED_ARRAY(info[0])) {
-      Napi::TypeError::New(env, "1st parameter (data) must be an Uint8ClampedArray in 'publishImageData'").ThrowAsJavaScriptException();
+      Napi::TypeError::New(env, "1st parameter (data) must be an "
+                                "Uint8ClampedArray in 'publishImageData'")
+          .ThrowAsJavaScriptException();
     }
 
     if (!IS_RECT(info[1])) {
-      Napi::TypeError::New(env, "2nd parameter (imageRegion) must be a rectangle in 'publishImageData'").ThrowAsJavaScriptException();
+      Napi::TypeError::New(env, "2nd parameter (imageRegion) must be a "
+                                "rectangle in 'publishImageData'")
+          .ThrowAsJavaScriptException();
     }
 
     if (!IS_SIZE(info[2])) {
-      Napi::TypeError::New(env, "3rd parameter (textureDimension) must be a size in 'publishImageData'").ThrowAsJavaScriptException();
+      Napi::TypeError::New(env, "3rd parameter (textureDimension) must be a "
+                                "size in 'publishImageData'")
+          .ThrowAsJavaScriptException();
     }
 
     if (!info[3].IsBoolean()) {
-      Napi::TypeError::New(env, "4th parameter (flipped) must be a boolean in 'publishImageData'").ThrowAsJavaScriptException();
+      Napi::TypeError::New(
+          env,
+          "4th parameter (flipped) must be a boolean in 'publishImageData'")
+          .ThrowAsJavaScriptException();
     }
 
     if (!IS_TEXTURE_TARGET(info[4])) {
-      Napi::TypeError::New(env, "5th parameter (textureTarget) must be a string containing GL_TEXTURE_RECTANGLE_EXT or GL_TEXTURE_2D in 'publishImageData'").ThrowAsJavaScriptException();
+      Napi::TypeError::New(
+          env,
+          "5th parameter (textureTarget) must be a string containing "
+          "GL_TEXTURE_RECTANGLE_EXT or GL_TEXTURE_2D in 'publishImageData'")
+          .ThrowAsJavaScriptException();
     }
 
     m_first_check_passed = true;
   }
 
   std::string targetString = info[4].As<Napi::String>().Utf8Value();
-  GLenum texture_target = targetString == "GL_TEXTURE_RECTANGLE_EXT" ? GL_TEXTURE_RECTANGLE_EXT : GL_TEXTURE_2D;
+  GLenum texture_target = targetString == "GL_TEXTURE_RECTANGLE_EXT"
+                              ? GL_TEXTURE_RECTANGLE_EXT
+                              : GL_TEXTURE_2D;
 
   Napi::Object region = info[1].As<Napi::Object>();
-  NSRect imageRegion = NSMakeRect(region.Get("x").ToNumber().FloatValue(), region.Get("y").ToNumber().FloatValue(), region.Get("width").ToNumber().FloatValue(), region.Get("height").ToNumber().FloatValue());
-  
+  NSRect imageRegion = NSMakeRect(region.Get("x").ToNumber().FloatValue(),
+                                  region.Get("y").ToNumber().FloatValue(),
+                                  region.Get("width").ToNumber().FloatValue(),
+                                  region.Get("height").ToNumber().FloatValue());
+
   Napi::Object size = info[2].As<Napi::Object>();
-  NSSize texture_size = NSMakeSize(size.Get("width").ToNumber().FloatValue(), size.Get("height").ToNumber().FloatValue());
+  NSSize texture_size = NSMakeSize(size.Get("width").ToNumber().FloatValue(),
+                                   size.Get("height").ToNumber().FloatValue());
 
   BOOL flipped = info[3].As<Napi::Boolean>().Value() == true ? YES : NO;
 
-  Napi::ArrayBuffer buffer = info[0].As<Napi::TypedArrayOf<uint8_t>>().ArrayBuffer(); 
+  Napi::ArrayBuffer buffer =
+      info[0].As<Napi::TypedArrayOf<uint8_t>>().ArrayBuffer();
 
   CGLSetCurrentContext([m_server context]);
 
   CGLLockContext(CGLGetCurrentContext());
-  glGenTextures(1, & m_texture);  
+  glGenTextures(1, &m_texture);
 
   OpenGLHelper::Uint8ToTexture(
-    texture_target, 
-    m_texture,
-    (size_t) texture_size.width, 
-    (size_t) texture_size.height,
-    (uint8_t *) buffer.Data()
-  );
+      texture_target, m_texture, (size_t)texture_size.width,
+      (size_t)texture_size.height, (uint8_t *)buffer.Data());
 
-  [m_server publishFrameTexture: m_texture 
-                  textureTarget: texture_target 
-                    imageRegion: imageRegion 
-              textureDimensions: texture_size 
-                        flipped: flipped
-  ];
+  [m_server publishFrameTexture:m_texture
+                  textureTarget:texture_target
+                    imageRegion:imageRegion
+              textureDimensions:texture_size
+                        flipped:flipped];
 
   glDeleteTextures(1, &m_texture);
   CGLSetCurrentContext(NULL);
 }
 
-void OpenGLServerWrapper::PublishSurfacehandle(const Napi::CallbackInfo& info)
-{
+void OpenGLServerWrapper::PublishSurfacehandle(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
   Napi::HandleScope scope(env);
 
-  // Only test the parameters on first call: we suppose that the function will be called 
-  // with same parameters, so we can avoid checking at each new frame.
+  // Only test the parameters on first call: we suppose that the function will
+  // be called with same parameters, so we can avoid checking at each new frame.
 
   if (!m_first_check_passed) {
     if (info.Length() != 5) {
-      Napi::TypeError::New(env, "Invalid number of parameters for 'publishSurfaceHandle'").ThrowAsJavaScriptException();
+      Napi::TypeError::New(
+          env, "Invalid number of parameters for 'publishSurfaceHandle'")
+          .ThrowAsJavaScriptException();
     }
-    
+
     if (!IS_BUFFER(info[0])) {
-      Napi::TypeError::New(env, "1st parameter (handle) must be a Buffer in 'publishSurfaceHandle'").ThrowAsJavaScriptException();
+      Napi::TypeError::New(
+          env,
+          "1st parameter (handle) must be a Buffer in 'publishSurfaceHandle'")
+          .ThrowAsJavaScriptException();
     }
 
     if (!IS_RECT(info[1])) {
-      Napi::TypeError::New(env, "2nd parameter (imageRegion) must be a rectangle in 'publishSurfaceHandle'").ThrowAsJavaScriptException();
+      Napi::TypeError::New(env, "2nd parameter (imageRegion) must be a "
+                                "rectangle in 'publishSurfaceHandle'")
+          .ThrowAsJavaScriptException();
     }
 
     if (!IS_SIZE(info[2])) {
-      Napi::TypeError::New(env, "3rd parameter (textureDimension) must be a size in 'publishSurfaceHandle'").ThrowAsJavaScriptException();
+      Napi::TypeError::New(env, "3rd parameter (textureDimension) must be a "
+                                "size in 'publishSurfaceHandle'")
+          .ThrowAsJavaScriptException();
     }
 
     if (!info[3].IsBoolean()) {
-      Napi::TypeError::New(env, "4th parameter (flipped) must be a boolean in 'publishSurfaceHandle'").ThrowAsJavaScriptException();
+      Napi::TypeError::New(
+          env,
+          "4th parameter (flipped) must be a boolean in 'publishSurfaceHandle'")
+          .ThrowAsJavaScriptException();
     }
 
     if (!IS_TEXTURE_TARGET(info[4])) {
-      Napi::TypeError::New(env, "5th2nd parameter (textureTarget) must be a string containing GL_TEXTURE_RECTANGLE_EXT or GL_TEXTURE_2D in 'publishSurfaceHandle'").ThrowAsJavaScriptException();
+      Napi::TypeError::New(
+          env,
+          "5th2nd parameter (textureTarget) must be a string containing "
+          "GL_TEXTURE_RECTANGLE_EXT or GL_TEXTURE_2D in 'publishSurfaceHandle'")
+          .ThrowAsJavaScriptException();
     }
 
     m_first_check_passed = true;
   }
 
-  // TODO: In a Promise (sequential?), since we can't use a worker on JS side (handle buffer is cloned).
+  // TODO: In a Promise (sequential?), since we can't use a worker on JS side
+  // (handle buffer is cloned).
 
   std::string targetString = info[4].As<Napi::String>().Utf8Value();
-  GLenum texture_target = targetString == "GL_TEXTURE_RECTANGLE_EXT" ? GL_TEXTURE_RECTANGLE_EXT : GL_TEXTURE_2D;
+  GLenum texture_target = targetString == "GL_TEXTURE_RECTANGLE_EXT"
+                              ? GL_TEXTURE_RECTANGLE_EXT
+                              : GL_TEXTURE_2D;
 
   Napi::Object region = info[1].As<Napi::Object>();
-  NSRect imageRegion = NSMakeRect(region.Get("x").ToNumber().FloatValue(), region.Get("y").ToNumber().FloatValue(), region.Get("width").ToNumber().FloatValue(), region.Get("height").ToNumber().FloatValue());
+  NSRect imageRegion = NSMakeRect(region.Get("x").ToNumber().FloatValue(),
+                                  region.Get("y").ToNumber().FloatValue(),
+                                  region.Get("width").ToNumber().FloatValue(),
+                                  region.Get("height").ToNumber().FloatValue());
 
   Napi::Object size = info[2].As<Napi::Object>();
-  NSSize texture_size = NSMakeSize(size.Get("width").ToNumber().FloatValue(), size.Get("height").ToNumber().FloatValue());
+  NSSize texture_size = NSMakeSize(size.Get("width").ToNumber().FloatValue(),
+                                   size.Get("height").ToNumber().FloatValue());
 
   BOOL flipped = info[3].As<Napi::Boolean>().Value() == true ? YES : NO;
 
-  auto buffer = info[0].As<Napi::Buffer<void**>>();
+  auto buffer = info[0].As<Napi::Buffer<void **>>();
 
-  IOSurfaceRef io_surface = *reinterpret_cast<IOSurfaceRef*>(buffer.Data());
+  IOSurfaceRef io_surface = *reinterpret_cast<IOSurfaceRef *>(buffer.Data());
   GLsizei width = (GLsizei)IOSurfaceGetWidth(io_surface);
   GLsizei height = (GLsizei)IOSurfaceGetHeight(io_surface);
 
@@ -182,20 +217,19 @@ void OpenGLServerWrapper::PublishSurfacehandle(const Napi::CallbackInfo& info)
   glEnable(GL_TEXTURE_RECTANGLE_ARB);
   glBindTexture(GL_TEXTURE_RECTANGLE_ARB, m_texture);
 
-  CGLTexImageIOSurface2D(CGLGetCurrentContext(), GL_TEXTURE_RECTANGLE_ARB, GL_RGBA8, width,
-                          height, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV,
-                          io_surface, 0);
+  CGLTexImageIOSurface2D(CGLGetCurrentContext(), GL_TEXTURE_RECTANGLE_ARB,
+                         GL_RGBA8, width, height, GL_BGRA,
+                         GL_UNSIGNED_INT_8_8_8_8_REV, io_surface, 0);
 
   glTexParameteri(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
   glTexParameteri(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
   glBindTexture(GL_TEXTURE_RECTANGLE_ARB, 0);
-  
-  [m_server publishFrameTexture: m_texture 
-                  textureTarget: texture_target 
-                    imageRegion: imageRegion 
-              textureDimensions: texture_size 
-                        flipped: flipped
-  ];
+
+  [m_server publishFrameTexture:m_texture
+                  textureTarget:texture_target
+                    imageRegion:imageRegion
+              textureDimensions:texture_size
+                        flipped:flipped];
 
   glDeleteTextures(1, &m_texture);
   CGLUnlockContext(CGLGetCurrentContext());
@@ -204,25 +238,17 @@ void OpenGLServerWrapper::PublishSurfacehandle(const Napi::CallbackInfo& info)
   /*
   // TODO: Add to helpers.
   CGLError cglError =
-  CGLTexImageIOSurface2D(CGLGetCurrentContext(), GL_TEXTURE_RECTANGLE_EXT, GL_RGBA, (GLsizei)surface_w, (GLsizei)surface_h, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, surface, 0);
-  if (cglError != kCGLNoError) {
-    if (cglError == kCGLBadAttribute) {
-      printf("Bad attribute.\n");
-    } else if (cglError == kCGLBadProperty) {
-      printf("Bad prop.\n");
-    } else if (cglError == kCGLBadPixelFormat) {
-      printf("Bad pixel.\n");
-    } else if (cglError == kCGLBadRendererInfo) {
-      printf("Bad renderer.\n");
-    } else if (cglError == kCGLBadContext) {
-      printf("Bad context.\n");
-    } else if (cglError == kCGLBadDrawable) {
-      printf("Bad drawable.\n");
-    } else if (cglError == kCGLBadDisplay) {
-      printf("Bad display.\n");
-    } else if (cglError == kCGLBadState) {
-      printf("Bad state.\n");
-    } else if (cglError == kCGLBadValue) {
+  CGLTexImageIOSurface2D(CGLGetCurrentContext(), GL_TEXTURE_RECTANGLE_EXT,
+  GL_RGBA, (GLsizei)surface_w, (GLsizei)surface_h, GL_BGRA,
+  GL_UNSIGNED_INT_8_8_8_8_REV, surface, 0); if (cglError != kCGLNoError) { if
+  (cglError == kCGLBadAttribute) { printf("Bad attribute.\n"); } else if
+  (cglError == kCGLBadProperty) { printf("Bad prop.\n"); } else if (cglError ==
+  kCGLBadPixelFormat) { printf("Bad pixel.\n"); } else if (cglError ==
+  kCGLBadRendererInfo) { printf("Bad renderer.\n"); } else if (cglError ==
+  kCGLBadContext) { printf("Bad context.\n"); } else if (cglError ==
+  kCGLBadDrawable) { printf("Bad drawable.\n"); } else if (cglError ==
+  kCGLBadDisplay) { printf("Bad display.\n"); } else if (cglError ==
+  kCGLBadState) { printf("Bad state.\n"); } else if (cglError == kCGLBadValue) {
       printf("Bad value.\n");
     } else if (cglError == kCGLBadMatch) {
       printf("Bad match.\n");
@@ -245,50 +271,55 @@ void OpenGLServerWrapper::PublishSurfacehandle(const Napi::CallbackInfo& info)
     }
   }
   */
-  
+
   // TODO: For client see 'Direct surface publishing' here:
   // https://github.com/Syphon/Syphon-Framework/pull/96
 }
 
-Napi::Value OpenGLServerWrapper::GetName(const Napi::CallbackInfo &info) 
-{
+Napi::Value OpenGLServerWrapper::GetName(const Napi::CallbackInfo &info) {
   return Napi::String::New(info.Env(), [[m_server name] UTF8String]);
 }
 
-Napi::Value OpenGLServerWrapper::GetServerDescription(const Napi::CallbackInfo &info) 
-{
-  return ServerDescriptionHelper::ToNapiObject([m_server serverDescription], info);
+Napi::Value
+OpenGLServerWrapper::GetServerDescription(const Napi::CallbackInfo &info) {
+  return ServerDescriptionHelper::ToNapiObject([m_server serverDescription],
+                                               info);
 }
 
-Napi::Value OpenGLServerWrapper::HasClients(const Napi::CallbackInfo &info) 
-{
+Napi::Value OpenGLServerWrapper::HasClients(const Napi::CallbackInfo &info) {
   return Napi::Boolean::New(info.Env(), [m_server hasClients]);
 }
 
 #pragma mark NAPI methods.
 
-bool OpenGLServerWrapper::HasInstance(Napi::Value value)
-{
+bool OpenGLServerWrapper::HasInstance(Napi::Value value) {
   return value.As<Napi::Object>().InstanceOf(constructor.Value());
 }
 
-Napi::Object OpenGLServerWrapper::Init(Napi::Env env, Napi::Object exports)
-{
-	Napi::HandleScope scope(env);
+Napi::Object OpenGLServerWrapper::Init(Napi::Env env, Napi::Object exports) {
+  Napi::HandleScope scope(env);
 
-  Napi::Function func = DefineClass(env, "OpenGLServer", {
+  Napi::Function func = DefineClass(
+      env, "OpenGLServer",
+      {
 
-    // Methods.
+          // Methods.
 
-    InstanceMethod("publishImageData", &OpenGLServerWrapper::PublishImageData),
-    InstanceMethod("publishSurfaceHandle", &OpenGLServerWrapper::PublishSurfacehandle),
-    InstanceMethod("dispose", &OpenGLServerWrapper::Dispose),
+          InstanceMethod("publishImageData",
+                         &OpenGLServerWrapper::PublishImageData),
+          InstanceMethod("publishSurfaceHandle",
+                         &OpenGLServerWrapper::PublishSurfacehandle),
+          InstanceMethod("dispose", &OpenGLServerWrapper::Dispose),
 
-    InstanceAccessor("name", &OpenGLServerWrapper::GetName, nullptr, napi_enumerable),
-    InstanceAccessor("serverDescription", &OpenGLServerWrapper::GetServerDescription, nullptr, napi_enumerable),
-    InstanceAccessor("hasClients", &OpenGLServerWrapper::HasClients, nullptr, napi_enumerable),    
+          InstanceAccessor("name", &OpenGLServerWrapper::GetName, nullptr,
+                           napi_enumerable),
+          InstanceAccessor("serverDescription",
+                           &OpenGLServerWrapper::GetServerDescription, nullptr,
+                           napi_enumerable),
+          InstanceAccessor("hasClients", &OpenGLServerWrapper::HasClients,
+                           nullptr, napi_enumerable),
 
-  });
+      });
 
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();

--- a/src/addon/promises/NSRunLoopPromiseWorker.h
+++ b/src/addon/promises/NSRunLoopPromiseWorker.h
@@ -1,36 +1,33 @@
 #ifndef __NS_RUN_LOOP_PROMISE_WORKER_H__
 #define __NS_RUN_LOOP_PROMISE_WORKER_H__
 
-#include <napi.h>
-#include <Foundation/Foundation.h>
-#include <Cocoa/Cocoa.h>
 #include "PromiseWorker.h"
+#include <Cocoa/Cocoa.h>
+#include <Foundation/Foundation.h>
+#include <napi.h>
 
 using namespace syphon;
 
 // Was an attempt to run an NSRunLoop in a Promise.
-class NSRunLoopPromiseWorker : public PromiseWorker
-{
+class NSRunLoopPromiseWorker : public PromiseWorker {
 
 public:
   NSRunLoopPromiseWorker(Napi::Promise::Deferred const &d) : PromiseWorker(d) {}
-  virtual ~NSRunLoopPromiseWorker(){};
+  virtual ~NSRunLoopPromiseWorker() {};
 
-  void Execute()
-  {
+  void Execute() {
     // No napi or js function may be called here.
-    // TODO: Find a way to get pixel buffer here. For the time being this promise is... synchronous :)
+    // TODO: Find a way to get pixel buffer here. For the time being this
+    // promise is... synchronous :)
   }
 
-  void OnOK()
-  {
+  void OnOK() {
     printf("Run Loop\n");
     [[NSRunLoop currentRunLoop] run];
     return;
   }
 
-  void OnError(const Napi::Error &e)
-  {
+  void OnError(const Napi::Error &e) {
     this->deferred.Reject(e.Value());
     return;
   }

--- a/src/addon/promises/PixelBufferPromiseWorker.h
+++ b/src/addon/promises/PixelBufferPromiseWorker.h
@@ -7,43 +7,44 @@
 
 using namespace syphon;
 
-// Was used for pulling frames from server -> replaced by 'On' callback in servers.
+// Was used for pulling frames from server -> replaced by 'On' callback in
+// servers.
 
-class PixelBufferPromiseWorker : public PromiseWorker
-{
+class PixelBufferPromiseWorker : public PromiseWorker {
 
 public:
-  PixelBufferPromiseWorker(Napi::Promise::Deferred const &d, uint8_t *pixel_buffer, size_t width, size_t height) : PromiseWorker(d)
-  {
+  PixelBufferPromiseWorker(Napi::Promise::Deferred const &d,
+                           uint8_t *pixel_buffer, size_t width, size_t height)
+      : PromiseWorker(d) {
     this->m_pixel_buffer = pixel_buffer;
     this->m_width = width;
     this->m_height = height;
   }
-  virtual ~PixelBufferPromiseWorker(){};
+  virtual ~PixelBufferPromiseWorker() {};
 
-  void Execute()
-  {
+  void Execute() {
     // No napi or js function may be called here.
-    // TODO: Find a way to get pixel buffer here. For the time being this promise is... synchronous :)
+    // TODO: Find a way to get pixel buffer here. For the time being this
+    // promise is... synchronous :)
   }
 
-  void OnOK()
-  {
-    auto buffer = Napi::Buffer<uint8_t>::NewOrCopy(Env(), m_pixel_buffer, m_width * m_height * 4, [](Napi::BasicEnv, void* finalizeData) {
-      delete[] static_cast<uint8_t*>(finalizeData);
-    });
+  void OnOK() {
+    auto buffer = Napi::Buffer<uint8_t>::NewOrCopy(
+        Env(), m_pixel_buffer, m_width * m_height * 4,
+        [](Napi::BasicEnv, void *finalizeData) {
+          delete[] static_cast<uint8_t *>(finalizeData);
+        });
     this->deferred.Resolve(buffer);
     return;
   }
 
-  void OnError(const Napi::Error &e)
-  {
+  void OnError(const Napi::Error &e) {
     this->deferred.Reject(e.Value());
     return;
   }
 
 private:
-  uint8_t * m_pixel_buffer;
+  uint8_t *m_pixel_buffer;
   size_t m_width;
   size_t m_height;
 };

--- a/src/addon/promises/PromiseWorker.h
+++ b/src/addon/promises/PromiseWorker.h
@@ -3,29 +3,27 @@
 
 #include <napi.h>
 
-namespace syphon
-{
+namespace syphon {
 
-  class PromiseWorker : public Napi::AsyncWorker
-  {
+class PromiseWorker : public Napi::AsyncWorker {
 
-  public:
-    PromiseWorker(Napi::Promise::Deferred const &d)
-        : Napi::AsyncWorker(get_fake_callback(d.Env()).Value()), deferred(d)
-    {
+public:
+  PromiseWorker(Napi::Promise::Deferred const &d)
+      : Napi::AsyncWorker(get_fake_callback(d.Env()).Value()), deferred(d) {
 
-      this->deferred = d;
-    }
-    virtual ~PromiseWorker(){};
+    this->deferred = d;
+  }
+  virtual ~PromiseWorker() {};
 
-  protected:
-    Napi::Promise::Deferred deferred;
+protected:
+  Napi::Promise::Deferred deferred;
 
-  private:
-    static Napi::Value noop(Napi::CallbackInfo const &info);
-    static Napi::Reference<Napi::Function> const &get_fake_callback(Napi::Env const &env);
-  };
+private:
+  static Napi::Value noop(Napi::CallbackInfo const &info);
+  static Napi::Reference<Napi::Function> const &
+  get_fake_callback(Napi::Env const &env);
+};
 
-}
+} // namespace syphon
 
 #endif

--- a/src/addon/promises/PromiseWorker.mm
+++ b/src/addon/promises/PromiseWorker.mm
@@ -4,17 +4,16 @@ using namespace syphon;
 
 static Napi::Reference<Napi::Function> fake_callback;
 
-Napi::Value PromiseWorker::noop(Napi::CallbackInfo const &info)
-{
+Napi::Value PromiseWorker::noop(Napi::CallbackInfo const &info) {
   return info.Env().Undefined();
 }
 
-Napi::Reference<Napi::Function> const &PromiseWorker::get_fake_callback(Napi::Env const &env)
-{
+Napi::Reference<Napi::Function> const &
+PromiseWorker::get_fake_callback(Napi::Env const &env) {
   static Napi::Reference<Napi::Function> fake_callback;
-  if (fake_callback.IsEmpty())
-  {
-    fake_callback = Napi::Reference<Napi::Function>::New(Napi::Function::New(env, noop), 1);
+  if (fake_callback.IsEmpty()) {
+    fake_callback =
+        Napi::Reference<Napi::Function>::New(Napi::Function::New(env, noop), 1);
   }
 
   return fake_callback;

--- a/src/main/node/client.gl.ts
+++ b/src/main/node/client.gl.ts
@@ -23,14 +23,18 @@ export class SyphonOpenGLClient {
   public dispose() {
     this.listeners.length = 0;
     this.isFrameListenerSet = false;
-
-    // FIXME: Not sure it is actually calling dipose in addon.
     this.client.dispose(); // Will also remove addon's listener.
   }
 
   public on(channel: string, callback: (frame: SyphonFrameData) => void) {
     switch (channel) {
       case 'frame': {
+        process.emitWarning(
+          `SyphonOpenGLClient.on('frame') is deprecated. Use on('data') instead.`,
+          'DeprecationWarning'
+        );
+      }
+      case 'data': {
         if (!this.isFrameListenerSet) {
           // Set only one frame listener and prepare to dispatch to Javascript listeners.
           this.client.on('frame', this.frameDataListenerCallback.bind(this));
@@ -45,6 +49,12 @@ export class SyphonOpenGLClient {
   public off(channel: string, callback: (frame: SyphonFrameData) => void) {
     switch (channel) {
       case 'frame': {
+        process.emitWarning(
+          `SyphonOpenGLClient.off('frame') is deprecated. Use off('data') instead.`,
+          'DeprecationWarning'
+        );
+      }
+      case 'data': {
         const index = this.listeners.indexOf(callback);
         if (index >= 0) {
           this.listeners.splice(index, 1);

--- a/src/main/node/client.metal.ts
+++ b/src/main/node/client.metal.ts
@@ -32,6 +32,12 @@ export class SyphonMetalClient {
   public on(channel: string, callback: (frame: SyphonFrameData) => void) {
     switch (channel) {
       case 'frame': {
+        process.emitWarning(
+          `SyphonMetalClient.on('frame') is deprecated. Use on('data') instead.`,
+          'DeprecationWarning'
+        );
+      }
+      case 'data': {
         if (!this.isFrameListenerSet) {
           // Set only one frame listener and prepare to dispatch to Javascript listeners.
           this.client.on('frame', this.frameDataListenerCallback.bind(this));

--- a/src/main/node/client.metal.ts
+++ b/src/main/node/client.metal.ts
@@ -22,7 +22,6 @@ export class SyphonMetalClient {
   }
 
   public dispose() {
-    console.log('DISPOSE CLIENT');
     this.frameListeners.length = 0;
     this.isFrameListenerSet = false;
     this.textureListeners.length = 0;
@@ -42,9 +41,7 @@ export class SyphonMetalClient {
         break;
       }
       case 'texture': {
-        console.log('Trying to bind event listener');
         if (!this.isTextureListenerSet) {
-          console.log('GO');
           // Set only one frame listener and prepare to dispatch to Javascript listeners.
           this.client.on('texture', this.textureHandleListenerCallback.bind(this));
           this.isTextureListenerSet = true;
@@ -92,7 +89,12 @@ export class SyphonMetalClient {
 
   private textureHandleListenerCallback(frame: any): void {
     for (const listener of this.textureListeners) {
-      listener(frame);
+      listener({
+        ...frame,
+        release: () => {
+          this.client.releaseTexture(frame.frameCount);
+        },
+      });
     }
   }
 }

--- a/src/main/node/client.metal.ts
+++ b/src/main/node/client.metal.ts
@@ -5,24 +5,28 @@ import type { SyphonServerDescription } from '../../common/types';
 // TODO: Test with window handle.
 export interface SyphonMetalClientConstructorOptions {
   server: SyphonServerDescription;
-  handle?: Buffer;
 }
 
 export type { SyphonFrameData };
 
 export class SyphonMetalClient {
   private client: any;
-  private listeners: ((frame: SyphonFrameData) => void)[] = [];
+  private frameListeners: ((frame: SyphonFrameData) => void)[] = [];
+  private textureListeners: ((texture: any) => void)[] = [];
 
   private isFrameListenerSet = false;
+  private isTextureListenerSet = false;
 
   constructor(description: SyphonServerDescription) {
     this.client = new SyphonAddon.MetalClient(description);
   }
 
   public dispose() {
-    this.listeners.length = 0;
+    console.log('DISPOSE CLIENT');
+    this.frameListeners.length = 0;
     this.isFrameListenerSet = false;
+    this.textureListeners.length = 0;
+    this.isTextureListenerSet = false;
     this.client.dispose(); // Will also remove addon's listener.
   }
 
@@ -34,7 +38,18 @@ export class SyphonMetalClient {
           this.client.on('frame', this.frameDataListenerCallback.bind(this));
           this.isFrameListenerSet = true;
         }
-        this.listeners.push(callback);
+        this.frameListeners.push(callback);
+        break;
+      }
+      case 'texture': {
+        console.log('Trying to bind event listener');
+        if (!this.isTextureListenerSet) {
+          console.log('GO');
+          // Set only one frame listener and prepare to dispatch to Javascript listeners.
+          this.client.on('texture', this.textureHandleListenerCallback.bind(this));
+          this.isTextureListenerSet = true;
+        }
+        this.textureListeners.push(callback);
         break;
       }
     }
@@ -43,13 +58,25 @@ export class SyphonMetalClient {
   public off(channel: string, callback: (frame: SyphonFrameData) => void) {
     switch (channel) {
       case 'frame': {
-        const index = this.listeners.indexOf(callback);
+        const index = this.frameListeners.indexOf(callback);
         if (index >= 0) {
-          this.listeners.splice(index, 1);
+          this.frameListeners.splice(index, 1);
 
-          if (this.listeners.length === 0) {
+          if (this.frameListeners.length === 0) {
             this.client.off('frame');
             this.isFrameListenerSet = false;
+          }
+        }
+        break;
+      }
+      case 'texture': {
+        const index = this.textureListeners.indexOf(callback);
+        if (index >= 0) {
+          this.textureListeners.splice(index, 1);
+
+          if (this.textureListeners.length === 0) {
+            this.client.off('texture');
+            this.isTextureListenerSet = false;
           }
         }
         break;
@@ -58,7 +85,13 @@ export class SyphonMetalClient {
   }
 
   private frameDataListenerCallback(frame: SyphonFrameData): void {
-    for (const listener of this.listeners) {
+    for (const listener of this.frameListeners) {
+      listener(frame);
+    }
+  }
+
+  private textureHandleListenerCallback(frame: any): void {
+    for (const listener of this.textureListeners) {
       listener(frame);
     }
   }


### PR DESCRIPTION
**Description of change**

- Convert Syphon frame to new IOSurface and pass it in a JS callback (@RenaudRohlinger).
- Use experimental Electron's [import External Texture](https://github.com/electron/electron/pull/46811#issue-3021763116) to pass the surface to renderer process.
- Add a new TS API `on('texture')` to listen to incoming IOSurface handles.

**Notes**

An example is available [here](https://github.com/benoitlahoz?tab=repositories)