### PR TITLE
Fix memory leak in SyphonMetalServer.publishImageData (release the per-frame texture)

### DIFF
--- a/src/addon/metal/MetalServer.mm
+++ b/src/addon/metal/MetalServer.mm
@@ -109,27 +109,29 @@ void MetalServerWrapper::PublishImageData(const Napi::CallbackInfo &info) {
                                   height:(NSUInteger)texture_size.height
                                mipmapped:NO];
 
-  m_texture = [m_device newTextureWithDescriptor:descriptor];
-  [m_texture replaceRegion:MTLRegionMake2D(
-                               imageRegion.origin.x, imageRegion.origin.y,
-                               imageRegion.size.width, imageRegion.size.height)
-               mipmapLevel:0
-                 withBytes:buffer.Data()
-               bytesPerRow:bytesPerRow];
+  id<MTLTexture> texture = [m_device newTextureWithDescriptor:descriptor];
+  [texture replaceRegion:MTLRegionMake2D(
+                             imageRegion.origin.x, imageRegion.origin.y,
+                             imageRegion.size.width, imageRegion.size.height)
+             mipmapLevel:0
+               withBytes:buffer.Data()
+             bytesPerRow:bytesPerRow];
 
   id<MTLCommandBuffer> cmd = [m_queue commandBuffer];
 
-  [m_server publishFrameTexture:m_texture
+  [m_server publishFrameTexture:texture
                 onCommandBuffer:cmd
                     imageRegion:imageRegion
                         flipped:flipped];
 
-  // @RenaudRohlinger Should we add this?
-  /*
+  // Release this frame's texture once the GPU has finished reading it. Without
+  // this, every publishImageData call leaks one MTLTexture (manual retain/release:
+  // -newTextureWithDescriptor: returns a +1-owned object). A LOCAL texture (not the
+  // m_texture ivar) is captured by the block so overlapping frames can't release
+  // each other's texture. Mirrors PublishSurfaceHandle below.
   [cmd addCompletedHandler:^(__unused id<MTLCommandBuffer> cb) {
-      [m_texture release];          // keep lifetime until GPU is done
+    [texture release];
   }];
-  */
   [cmd commit];
 }
 


### PR DESCRIPTION
Thanks for building this — it's the cleanest way I've found to get frames out of Node and into the Syphon ecosystem.

I'm using it to feed live rendered frames into Resolume Arena for VJ performances. My app is WebGL-based, so its frames come back from the GPU as CPU pixels and go out through `publishImageData` rather than the GPU-texture path most native apps use, which is what exposed this leak. It was severe in my case: roughly one full-resolution texture leaked per published frame, which at video frame rates drove memory past my 64 GB of RAM within a few minutes of broadcasting and triggered the macOS out-of-memory warning.

The cause is in `MetalServer.mm`: `publishImageData` allocates a new `MTLTexture` every call (`newTextureWithDescriptor:`, a +1-owned object under manual retain/release) and never releases it. There's already a commented-out attempt at the fix in the file (the `// @RenaudRohlinger Should we add this?` block), and it was most of the way there. The one gotcha: it releases the shared `m_texture` instance variable, which isn't safe if a later frame overwrites `m_texture` before the previous frame's GPU work completes. Capturing the texture in a **local** variable and releasing it in the command buffer's `addCompletedHandler` resolves both the leak and that race. It's the same pattern `PublishSurfaceHandle` already uses just below.

Measured with a fixed-buffer publish loop: RSS holds flat at ~110 MB across 400 publishes, versus ~5.7 GB before. It's also been stable over multi-minute live broadcasts into Arena.

Disclosure, in the spirit of transparency: I found and wrote this with Claude Code while building my app on node-syphon. Glad to contribute the fix back, though I'm not in a position to commit to ongoing maintenance. Thanks again for the library.

Closes #45.
